### PR TITLE
Use Mockito injection in server unit tests

### DIFF
--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/ByteArrayToHexTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/ByteArrayToHexTest.java
@@ -1,0 +1,27 @@
+package pl.grzeslowski.openhab.supla.internal.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ByteArrayToHexTest {
+    @Test
+    void shouldConvertBytesToHexAndBack() {
+        byte[] input = new byte[] {0x00, 0x0A, (byte) 0xFF};
+
+        String hex = ByteArrayToHex.bytesToHex(input);
+        byte[] result = ByteArrayToHex.hexToBytes(hex);
+
+        assertThat(hex).isEqualTo("000AFF");
+        assertThat(result).containsExactly(input);
+    }
+
+    @Test
+    void shouldHandleEmptyArray() {
+        String hex = ByteArrayToHex.bytesToHex(new byte[0]);
+        byte[] result = ByteArrayToHex.hexToBytes(hex);
+
+        assertThat(hex).isEmpty();
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/ChannelCallbackTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/ChannelCallbackTest.java
@@ -1,0 +1,86 @@
+package pl.grzeslowski.openhab.supla.internal.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ChannelIds.Hvac.HVAC_MODE_CHANNEL_ID;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ChannelIds.Hvac.HVAC_TEMPERATURE_COOL_CHANNEL_ID;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ChannelIds.Hvac.HVAC_TEMPERATURE_HEAT_CHANNEL_ID;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ChannelIds.Hvac.HVAC_WORKING_CHANNEL_ID;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ChannelIds.UNKNOWN_CHANNEL_ID;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.Channels.HUMIDITY_CHANNEL_ID;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.Channels.SWITCH_CHANNEL_ID;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.Channels.TEMPERATURE_CHANNEL_ID;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.ChannelGroupUID;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.type.ChannelTypeUID;
+import pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants;
+
+class ChannelCallbackTest {
+    private final ThingUID thingUID = new ThingUID("supla:test:1");
+
+    @Test
+    void shouldCreateSwitchChannel() {
+        var callback = new ChannelCallback(thingUID, 5);
+
+        List<Channel> channels = callback.onOnOff().toList();
+
+        assertThat(channels).singleElement().satisfies(channel -> {
+            assertThat(channel.getUID()).isEqualTo(new ChannelUID(thingUID, "5"));
+            assertThat(channel.getChannelTypeUID())
+                    .isEqualTo(new ChannelTypeUID(SuplaBindingConstants.BINDING_ID, SWITCH_CHANNEL_ID));
+            assertThat(channel.getLabel()).isEqualTo("Allows you to turn thing ON/OFF");
+            assertThat(channel.getAcceptedItemType()).isEqualTo("Switch");
+        });
+    }
+
+    @Test
+    void shouldCreateTemperatureAndHumidityGroup() {
+        var callback = new ChannelCallback(thingUID, 3);
+
+        List<Channel> channels = callback.onTemperatureAndHumidityValue().toList();
+
+        assertThat(channels).hasSize(2);
+        assertThat(channels)
+                .extracting(Channel::getUID)
+                .containsExactly(
+                        new ChannelUID(new ChannelGroupUID(thingUID, "3"), "temperature"),
+                        new ChannelUID(new ChannelGroupUID(thingUID, "3"), "humidity"));
+        assertThat(channels)
+                .extracting(Channel::getChannelTypeUID)
+                .containsExactly(
+                        new ChannelTypeUID(SuplaBindingConstants.BINDING_ID, TEMPERATURE_CHANNEL_ID),
+                        new ChannelTypeUID(SuplaBindingConstants.BINDING_ID, HUMIDITY_CHANNEL_ID));
+    }
+
+    @Test
+    void shouldCreateHvacChannels() {
+        var callback = new ChannelCallback(thingUID, 7);
+
+        List<Channel> channels = callback.onHvacValue().toList();
+
+        assertThat(channels).hasSizeGreaterThanOrEqualTo(4);
+        assertThat(channels)
+                .extracting(Channel::getChannelTypeUID)
+                .contains(
+                        new ChannelTypeUID(SuplaBindingConstants.BINDING_ID, HVAC_WORKING_CHANNEL_ID),
+                        new ChannelTypeUID(SuplaBindingConstants.BINDING_ID, HVAC_MODE_CHANNEL_ID),
+                        new ChannelTypeUID(SuplaBindingConstants.BINDING_ID, HVAC_TEMPERATURE_HEAT_CHANNEL_ID),
+                        new ChannelTypeUID(SuplaBindingConstants.BINDING_ID, HVAC_TEMPERATURE_COOL_CHANNEL_ID));
+    }
+
+    @Test
+    void shouldCreateUnknownChannel() {
+        var callback = new ChannelCallback(thingUID, 10);
+
+        Channel channel = callback.onUnknownValue().findFirst().orElseThrow();
+
+        assertThat(channel.getUID()).isEqualTo(new ChannelUID(thingUID, "10"));
+        assertThat(channel.getChannelTypeUID())
+                .isEqualTo(new ChannelTypeUID(SuplaBindingConstants.BINDING_ID, UNKNOWN_CHANNEL_ID));
+        assertThat(channel.getLabel()).isEqualTo("Unknown");
+    }
+}

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/ChannelUtilTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/ChannelUtilTest.java
@@ -1,0 +1,147 @@
+package pl.grzeslowski.openhab.supla.internal.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.ChannelGroupUID;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.binding.builder.ThingBuilder;
+import org.openhab.core.types.State;
+import org.slf4j.Logger;
+import pl.grzeslowski.openhab.supla.internal.server.handler.trait.SuplaDevice;
+import pl.grzeslowski.openhab.supla.internal.server.traits.DeviceChannelValue;
+
+@ExtendWith(MockitoExtension.class)
+class ChannelUtilTest {
+    @Mock
+    private SuplaDevice suplaDevice;
+
+    @Mock
+    private Logger logger;
+
+    @Mock
+    private Thing thing;
+
+    @Mock
+    private ThingBuilder thingBuilder;
+
+    private HashMap<Integer, Integer> channelTypes;
+
+    @InjectMocks
+    private ChannelUtil channelUtil;
+
+    @BeforeEach
+    void setUp() {
+        channelTypes = new HashMap<>();
+
+        when(suplaDevice.getLogger()).thenReturn(logger);
+        when(suplaDevice.getThing()).thenReturn(thing);
+        when(suplaDevice.getChannelTypes()).thenReturn(channelTypes);
+        when(suplaDevice.editThing()).thenReturn(thingBuilder);
+        when(thingBuilder.withChannels(any())).thenReturn(thingBuilder);
+    }
+
+    @Test
+    void shouldSkipOfflineStatusUpdate() {
+        var channelValue = new DeviceChannelValue(4, new byte[] {0x01}, true, null);
+
+        channelUtil.updateStatus(channelValue);
+
+        verify(suplaDevice, never()).updateState(any(), any());
+        verify(suplaDevice, never()).saveState(any(), any());
+    }
+
+    @Test
+    void shouldFindIdFromChannelNumberWhenIdMissing() {
+        Optional<Integer> result = ChannelUtil.findId(null, (short) 12);
+
+        assertThat(result).hasValue(12);
+    }
+
+    @Test
+    void shouldPreferExplicitId() {
+        Optional<Integer> result = ChannelUtil.findId(7, (short) 13);
+
+        assertThat(result).hasValue(7);
+    }
+
+    @Test
+    void shouldParseChannelNumberFromGroup() {
+        var thingUid = new org.openhab.core.thing.ThingUID("supla:test:1");
+        ChannelUID channelUID = new ChannelUID(new ChannelGroupUID(thingUid, "2"), "power");
+
+        Optional<Short> number = ChannelUtil.findSuplaChannelNumber(channelUID);
+
+        assertThat(number).hasValue((short) 2);
+    }
+
+    @Test
+    void shouldParseChannelNumberFromId() {
+        var thingUid = new org.openhab.core.thing.ThingUID("supla:test:1");
+        ChannelUID channelUID = new ChannelUID(thingUid, "11");
+
+        Optional<Short> number = ChannelUtil.findSuplaChannelNumber(channelUID);
+
+        assertThat(number).hasValue((short) 11);
+    }
+
+    @Test
+    void shouldIgnoreNonNumericIds() {
+        var thingUid = new org.openhab.core.thing.ThingUID("supla:test:1");
+        ChannelUID channelUID = new ChannelUID(thingUid, "abc");
+
+        Optional<Short> number = ChannelUtil.findSuplaChannelNumber(channelUID);
+
+        assertThat(number).isEmpty();
+    }
+
+    @Test
+    void shouldDropStoredSenderEntryOnSuccess() {
+        var map = new HashMap<Integer, SuplaDevice.ChannelAndPreviousState>();
+        var channelUID = new ChannelUID("supla:test:1:1");
+        map.put(5, new SuplaDevice.ChannelAndPreviousState(channelUID, null));
+        when(suplaDevice.getSenderIdToChannelUID()).thenReturn(map);
+        var newValueResult = org.mockito.Mockito.mock(
+                pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaChannelNewValueResult.class);
+        when(newValueResult.senderId()).thenReturn(5);
+        when(newValueResult.success()).thenReturn((byte) 1);
+
+        channelUtil.consumeSuplaChannelNewValueResult(newValueResult);
+
+        assertThat(map).isEmpty();
+        verify(suplaDevice, never()).handleRefreshCommand(any(ChannelUID.class));
+    }
+
+    @Test
+    void shouldRefreshWhenSenderMissing() {
+        var map = new HashMap<Integer, SuplaDevice.ChannelAndPreviousState>();
+        when(suplaDevice.getSenderIdToChannelUID()).thenReturn(map);
+        var channelUID = new ChannelUID("supla:test:1:2");
+        var channel = org.mockito.Mockito.mock(Channel.class);
+        when(channel.getUID()).thenReturn(channelUID);
+        when(thing.getChannels()).thenReturn(new ArrayList<>(java.util.List.of(channel)));
+        var newValueResult = org.mockito.Mockito.mock(
+                pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaChannelNewValueResult.class);
+        when(newValueResult.senderId()).thenReturn(8);
+        when(newValueResult.channelNumber()).thenReturn((short) 2);
+        when(newValueResult.success()).thenReturn((byte) 0);
+
+        channelUtil.consumeSuplaChannelNewValueResult(newValueResult);
+
+        verify(suplaDevice).handleRefreshCommand(channelUID);
+    }
+}

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/ChannelValueToStateTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/ChannelValueToStateTest.java
@@ -1,0 +1,147 @@
+package pl.grzeslowski.openhab.supla.internal.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openhab.core.types.UnDefType.NULL;
+import static org.openhab.core.types.UnDefType.UNDEF;
+
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.core.library.types.DecimalType;
+import org.openhab.core.library.types.HSBType;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.library.types.PercentType;
+import org.openhab.core.library.types.StringType;
+import org.openhab.core.library.types.QuantityType;
+import org.openhab.core.thing.ChannelGroupUID;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.types.State;
+import pl.grzeslowski.jsupla.protocol.api.channeltype.value.DecimalValue;
+import pl.grzeslowski.jsupla.protocol.api.channeltype.value.PercentValue;
+import pl.grzeslowski.jsupla.protocol.api.channeltype.value.RgbValue;
+import pl.grzeslowski.jsupla.protocol.api.channeltype.value.StoppableOpenClose;
+import pl.grzeslowski.jsupla.protocol.api.channeltype.value.TemperatureAndHumidityValue;
+import pl.grzeslowski.jsupla.protocol.api.channeltype.value.TemperatureValue;
+import pl.grzeslowski.jsupla.protocol.api.channeltype.value.UnknownValue;
+import pl.grzeslowski.openhab.supla.internal.server.ChannelValueToState;
+
+@ExtendWith(MockitoExtension.class)
+class ChannelValueToStateTest {
+    private final ThingUID thingUID = new ThingUID("supla:test:1");
+
+    @Mock
+    private DecimalValue decimalValue;
+
+    @Mock
+    private PercentValue percentValue;
+
+    @Mock
+    private RgbValue rgbValue;
+
+    @Mock
+    private TemperatureValue temperatureValue;
+
+    @Mock
+    private TemperatureAndHumidityValue temperatureAndHumidityValue;
+
+    @Mock
+    private UnknownValue unknownValue;
+
+    @Test
+    void shouldConvertDecimalValue() {
+        var converter = new ChannelValueToState(thingUID, 2);
+        org.mockito.Mockito.when(decimalValue.value()).thenReturn(BigDecimal.TEN);
+
+        List<State> states = converter.onDecimalValue(decimalValue).map(pair -> pair.getValue1()).toList();
+
+        assertThat(states).containsExactly(new DecimalType(BigDecimal.TEN));
+    }
+
+    @Test
+    void shouldReturnNullForMissingDecimal() {
+        var converter = new ChannelValueToState(thingUID, 4);
+
+        List<State> states = converter.onDecimalValue(null).map(pair -> pair.getValue1()).toList();
+
+        assertThat(states).containsExactly(NULL);
+    }
+
+    @Test
+    void shouldConvertPercentAndRgb() {
+        var converter = new ChannelValueToState(thingUID, 6);
+        org.mockito.Mockito.when(percentValue.value()).thenReturn(new BigDecimal("55"));
+        org.mockito.Mockito.when(rgbValue.red()).thenReturn((short) 1);
+        org.mockito.Mockito.when(rgbValue.green()).thenReturn((short) 2);
+        org.mockito.Mockito.when(rgbValue.blue()).thenReturn((short) 3);
+
+        List<State> states = converter.onPercentValue(percentValue)
+                .map(pair -> pair.getValue1())
+                .concat(converter.onRgbValue(rgbValue).map(pair -> pair.getValue1()))
+                .toList();
+
+        assertThat(states).containsExactly(new PercentType(55), HSBType.fromRGB((short) 1, (short) 2, (short) 3));
+    }
+
+    @Test
+    void shouldReturnUndefForSpecialTemperatureValue() {
+        var converter = new ChannelValueToState(thingUID, 7);
+        org.mockito.Mockito.when(temperatureValue.temperature()).thenReturn(BigDecimal.valueOf(-275));
+
+        State state = converter.onTemperatureValue(temperatureValue).findFirst().orElseThrow().getValue1();
+
+        assertThat(state).isEqualTo(UNDEF);
+    }
+
+    @Test
+    void shouldMapTemperatureAndHumidityGroup() {
+        var converter = new ChannelValueToState(thingUID, 8);
+        org.mockito.Mockito.when(temperatureAndHumidityValue.temperature()).thenReturn(BigDecimal.valueOf(21));
+        org.mockito.Mockito.when(temperatureAndHumidityValue.humidity()).thenReturn(BigDecimal.valueOf(-1));
+
+        List<State> states = converter.onTemperatureAndHumidityValue(temperatureAndHumidityValue)
+                .map(pair -> pair.getValue1())
+                .toList();
+
+        assertThat(states)
+                .containsExactly(
+                        new QuantityType<>(BigDecimal.valueOf(21), org.openhab.core.library.unit.SIUnits.CELSIUS),
+                        UNDEF);
+    }
+
+    @Test
+    void shouldHandleStoppableOpenClose() {
+        var converter = new ChannelValueToState(thingUID, 9);
+
+        State state = converter.onStoppableOpenClose(StoppableOpenClose.STOP).findFirst().orElseThrow().getValue1();
+
+        assertThat(state).isEqualTo(OnOffType.from(false));
+    }
+
+    @Test
+    void shouldHandleUnknownValueNulls() {
+        var converter = new ChannelValueToState(thingUID, 5);
+
+        List<State> nullStates = converter.onUnknownValue(null).map(pair -> pair.getValue1()).toList();
+        List<State> messageStates = converter.onUnknownValue(unknownValue).map(pair -> pair.getValue1()).toList();
+
+        assertThat(nullStates).containsExactly(NULL);
+        org.mockito.Mockito.when(unknownValue.message()).thenReturn("oops");
+        assertThat(messageStates).containsExactly(new StringType("oops"));
+    }
+
+    @Test
+    void shouldReturnGroupedUidsForTemperatureAndHumidity() {
+        var converter = new ChannelValueToState(thingUID, 12);
+
+        List<ChannelUID> uids = converter.onTemperatureAndHumidityValue(null).map(pair -> pair.getValue0()).toList();
+
+        assertThat(uids)
+                .containsExactly(
+                        new ChannelUID(new ChannelGroupUID(thingUID, "12"), "temperature"),
+                        new ChannelUID(new ChannelGroupUID(thingUID, "12"), "humidity"));
+    }
+}

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/cache/InMemoryStateCacheTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/cache/InMemoryStateCacheTest.java
@@ -1,0 +1,52 @@
+package pl.grzeslowski.openhab.supla.internal.server.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.types.State;
+import org.slf4j.Logger;
+
+@ExtendWith(MockitoExtension.class)
+class InMemoryStateCacheTest {
+    @Mock
+    private Logger logger;
+
+    @InjectMocks
+    private InMemoryStateCache cache;
+
+    @Test
+    void shouldStoreAndReturnState() {
+        ChannelUID channelUID = new ChannelUID("binding:thing:1");
+        State state = new State() {
+            @Override
+            public String toFullString() {
+                return "state";
+            }
+        };
+
+        cache.saveState(channelUID, state);
+        var found = cache.findState(channelUID);
+
+        assertThat(found).isEqualTo(state);
+        verify(logger).debug("Saving state {}={}", channelUID, state);
+        verify(logger).debug("Current state for {} is {}", channelUID, state);
+    }
+
+    @Test
+    void shouldAllowNullState() {
+        ChannelUID channelUID = new ChannelUID("binding:thing:2");
+
+        cache.saveState(channelUID, null);
+        var found = cache.findState(channelUID);
+
+        assertThat(found).isNull();
+        verify(logger).debug("Saving state {}={}", channelUID, null);
+        verify(logger).debug("Current state for {} is {}", channelUID, null);
+    }
+}

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/device_config/DeviceConfigResultTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/device_config/DeviceConfigResultTest.java
@@ -1,0 +1,30 @@
+package pl.grzeslowski.openhab.supla.internal.server.device_config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static pl.grzeslowski.jsupla.protocol.api.consts.ProtoConsts.SUPLA_CONFIG_RESULT_DEVICE_NOT_FOUND;
+import static pl.grzeslowski.jsupla.protocol.api.consts.ProtoConsts.SUPLA_CONFIG_RESULT_TRUE;
+
+import org.junit.jupiter.api.Test;
+
+class DeviceConfigResultTest {
+    @Test
+    void shouldFindKnownResult() {
+        var result = DeviceConfigResult.findConfigResult(SUPLA_CONFIG_RESULT_TRUE);
+
+        assertThat(result).isEqualTo(DeviceConfigResult.TRUE);
+        assertThat(result.isSuccess()).isTrue();
+    }
+
+    @Test
+    void shouldFindSpecificFailure() {
+        var result = DeviceConfigResult.findConfigResult(SUPLA_CONFIG_RESULT_DEVICE_NOT_FOUND);
+
+        assertThat(result).isEqualTo(DeviceConfigResult.DEVICE_NOT_FOUND);
+        assertThat(result.isSuccess()).isFalse();
+    }
+
+    @Test
+    void shouldReturnUnknownForUnexpectedValue() {
+        assertThat(DeviceConfigResult.findConfigResult(999)).isEqualTo(DeviceConfigResult.UNKNOWN);
+    }
+}

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/device_config/DeviceConfigTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/device_config/DeviceConfigTest.java
@@ -1,0 +1,53 @@
+package pl.grzeslowski.openhab.supla.internal.server.device_config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class DeviceConfigTest {
+    @Test
+    void shouldParseDisableUserInterfaceWithoutRange() {
+        var config = DeviceConfig.DisableUserInterfaceConfig.parse(List.of("ENABLED"));
+
+        assertThat(config.userInterface()).isEqualTo(DeviceConfig.DisableUserInterfaceConfig.UserInterface.ENABLED);
+        assertThat(config.minTemp()).isNull();
+        assertThat(config.maxTemp()).isNull();
+    }
+
+    @Test
+    void shouldParseDisableUserInterfaceWithRange() {
+        var config = DeviceConfig.DisableUserInterfaceConfig.parse(List.of("PARTIAL", "18", "25"));
+
+        assertThat(config.userInterface()).isEqualTo(DeviceConfig.DisableUserInterfaceConfig.UserInterface.PARTIAL);
+        assertThat(config.minTemp()).isEqualTo(18);
+        assertThat(config.maxTemp()).isEqualTo(25);
+    }
+
+    @Test
+    void shouldParseHomeScreenContentConfig() {
+        var config = DeviceConfig.HomeScreenContentConfig.parse(List.of("TEMPERATURE", "TIME_DATE"));
+
+        assertThat(config.contents())
+                .containsExactly(
+                        DeviceConfig.HomeScreenContentConfig.HomeScreenContent.TEMPERATURE,
+                        DeviceConfig.HomeScreenContentConfig.HomeScreenContent.TIME_DATE);
+    }
+
+    @Test
+    void shouldParseHomeScreenOffDelayConfig() {
+        var config = DeviceConfig.HomeScreenOffDelayConfig.parse(List.of("true", "PT30S"));
+
+        assertThat(config.enabled()).isTrue();
+        assertThat(config.duration()).isEqualTo(Duration.ofSeconds(30));
+    }
+
+    @Test
+    void shouldParseStatusLedConfig() {
+        var config = DeviceConfig.StatusLedConfig.parse(List.of("OFF_WHEN_CONNECTED"));
+
+        assertThat(config.statusLed())
+                .isEqualTo(DeviceConfig.StatusLedConfig.StatusLed.OFF_WHEN_CONNECTED);
+    }
+}

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/device_config/DeviceConfigUtilTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/device_config/DeviceConfigUtilTest.java
@@ -1,0 +1,80 @@
+package pl.grzeslowski.openhab.supla.internal.server.device_config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static pl.grzeslowski.openhab.supla.internal.server.device_config.DeviceConfigField.AUTOMATIC_TIME_SYNC;
+import static pl.grzeslowski.openhab.supla.internal.server.device_config.DeviceConfigField.STATUS_LED;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class DeviceConfigUtilTest {
+    @Test
+    void shouldBuildDeviceConfigMapFromFieldsAndBytes() throws IOException {
+        var statusLed = new DeviceConfig.StatusLedConfig(DeviceConfig.StatusLedConfig.StatusLed.OFF_WHEN_CONNECTED);
+        var automaticTimeSync = new DeviceConfig.AutomaticTimeSyncConfig(true);
+        long fields = STATUS_LED.getMask() | AUTOMATIC_TIME_SYNC.getMask();
+
+        var output = new ByteArrayOutputStream();
+        output.write(statusLed.encode());
+        output.write(automaticTimeSync.encode());
+
+        Map<String, String> configMap = DeviceConfigUtil.buildDeviceConfig(fields, output.toByteArray());
+
+        assertThat(configMap)
+                .containsEntry("DEVICE_CONFIG_STATUS_LED", "OFF_WHEN_CONNECTED")
+                .containsEntry("DEVICE_CONFIG_AUTOMATIC_TIME_SYNC", "enabled");
+    }
+
+    @Test
+    void shouldParseDeviceConfigByName() {
+        var config = DeviceConfigUtil.parseDeviceConfig("ButtonVolumeConfig:55");
+
+        assertThat(config).isInstanceOf(DeviceConfig.ButtonVolumeConfig.class);
+        assertThat(((DeviceConfig.ButtonVolumeConfig) config).volume()).isEqualTo(55);
+    }
+
+    @Test
+    void shouldRejectMissingSeparatorWhenParsingDeviceConfig() {
+        assertThatThrownBy(() -> DeviceConfigUtil.parseDeviceConfig("InvalidString"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("at least one \"\:");
+    }
+
+    @Test
+    void shouldRejectUnknownDeviceConfigName() {
+        assertThatThrownBy(() -> DeviceConfigUtil.parseDeviceConfig("UnknownConfig:true"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("UnknownConfig");
+    }
+
+    @Test
+    void shouldRejectInvalidEnumValue() {
+        assertThatThrownBy(() -> DeviceConfigUtil.parseEnum("INVALID", DeviceConfig.StatusLedConfig.StatusLed.class))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Cannot parse enum");
+    }
+
+    @Test
+    void shouldRejectInvalidBooleanValue() {
+        assertThatThrownBy(() -> DeviceConfigUtil.parseBoolean("not-a-bool"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cannot parse boolean");
+    }
+
+    @Test
+    void shouldRejectInvalidDuration() {
+        assertThatThrownBy(() -> DeviceConfigUtil.parseDuration("INVALID"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cannot parse duration");
+    }
+
+    @Test
+    void shouldRejectInvalidInteger() {
+        assertThatThrownBy(() -> DeviceConfigUtil.parseInt("not-int"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cannot parse int");
+    }
+}

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/HandlerCommandTraitTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/HandlerCommandTraitTest.java
@@ -1,0 +1,107 @@
+package pl.grzeslowski.openhab.supla.internal.server.handler.trait;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.openhab.core.library.types.OnOffType.OFF;
+import static org.openhab.core.library.types.OnOffType.ON;
+import static org.openhab.core.thing.ThingStatus.ONLINE;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.core.library.types.OnOffType;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.types.State;
+import org.slf4j.Logger;
+
+@ExtendWith(MockitoExtension.class)
+class HandlerCommandTraitTest {
+    @Mock
+    private SuplaDevice suplaDevice;
+
+    @Mock
+    private Logger logger;
+
+    @InjectMocks
+    private HandlerCommandTrait handlerCommandTrait;
+
+    private AtomicInteger senderId;
+    private HashMap<Integer, SuplaDevice.ChannelAndPreviousState> senderMap;
+    private ChannelFuture successfulFuture;
+
+    @BeforeEach
+    void setUp() {
+        senderId = new AtomicInteger();
+        senderMap = new HashMap<>();
+        var channel = new EmbeddedChannel();
+        successfulFuture = new DefaultChannelPromise(channel).setSuccess(null);
+
+        when(suplaDevice.getLogger()).thenReturn(logger);
+        when(suplaDevice.getSenderId()).thenReturn(senderId);
+        when(suplaDevice.getSenderIdToChannelUID()).thenReturn(senderMap);
+        when(suplaDevice.write(any())).thenReturn(successfulFuture);
+    }
+
+    @Test
+    void shouldRefreshStateWhenPresent() {
+        ChannelUID channelUID = new ChannelUID("binding:thing:1");
+        State state = new State() {
+            @Override
+            public String toFullString() {
+                return "state";
+            }
+        };
+        when(suplaDevice.findState(channelUID)).thenReturn(state);
+
+        handlerCommandTrait.handleRefreshCommand(channelUID);
+
+        verify(suplaDevice).updateState(channelUID, state);
+    }
+
+    @Test
+    void shouldNotRefreshWhenStateMissing() {
+        ChannelUID channelUID = new ChannelUID("binding:thing:1");
+        when(suplaDevice.findState(channelUID)).thenReturn(null);
+
+        handlerCommandTrait.handleRefreshCommand(channelUID);
+
+        verify(suplaDevice, never()).updateState(any(), any());
+    }
+
+    @Test
+    void shouldSendOnOffCommandAndRecordPreviousState() {
+        ChannelUID channelUID = new ChannelUID("binding:thing:1");
+
+        handlerCommandTrait.handleOnOffCommand(channelUID, ON);
+
+        assertThat(senderMap).hasSize(1);
+        var entry = senderMap.entrySet().iterator().next();
+        assertThat(entry.getKey()).isZero();
+        SuplaDevice.ChannelAndPreviousState value = entry.getValue();
+        assertThat(value.channelUID()).isEqualTo(channelUID);
+        assertThat((OnOffType) value.previousState()).isEqualTo(OFF);
+        verify(suplaDevice).write(any());
+        verify(suplaDevice).updateStatus(ONLINE);
+    }
+
+    @Test
+    void shouldFailWhenChannelNumberCannotBeParsed() {
+        ChannelUID channelUID = new ChannelUID("binding:thing:notANumber");
+
+        assertThatThrownBy(() -> handlerCommandTrait.handleOnOffCommand(channelUID, ON))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cannot find channel number from");
+    }
+}

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/SuplaBridgeTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/SuplaBridgeTest.java
@@ -1,0 +1,58 @@
+package pl.grzeslowski.openhab.supla.internal.server.handler.trait;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+import pl.grzeslowski.openhab.supla.internal.server.oh_config.AuthData;
+import pl.grzeslowski.openhab.supla.internal.server.oh_config.ServerBridgeHandlerConfiguration;
+import pl.grzeslowski.openhab.supla.internal.server.oh_config.TimeoutConfiguration;
+
+class SuplaBridgeTest {
+
+    @Test
+    void shouldBuildAuthDataWithLocationAndEmail() {
+        var config = new ServerBridgeHandlerConfiguration();
+        config.setServerAccessId(BigDecimal.valueOf(123));
+        config.setServerAccessIdPassword("secret");
+        config.setEmail("user@example.com");
+        config.setAuthKey("key");
+
+        AuthData authData = SuplaBridge.buildAuthData(config);
+
+        assertThat(authData.locationAuthData()).isNotNull();
+        assertThat(authData.locationAuthData().serverAccessId()).isEqualTo(123);
+        assertThat(authData.locationAuthData().serverAccessIdPassword()).isEqualTo("secret");
+        assertThat(authData.emailAuthData()).isNotNull();
+        assertThat(authData.emailAuthData().email()).isEqualTo("user@example.com");
+        assertThat(authData.emailAuthData().authKey()).isEqualTo("key");
+    }
+
+    @Test
+    void shouldBuildAuthDataOnlyWithEmail() {
+        var config = new ServerBridgeHandlerConfiguration();
+        config.setEmail("user@example.com");
+        config.setAuthKey("key");
+
+        AuthData authData = SuplaBridge.buildAuthData(config);
+
+        assertThat(authData.locationAuthData()).isNull();
+        assertThat(authData.emailAuthData()).isNotNull();
+        assertThat(authData.emailAuthData().email()).isEqualTo("user@example.com");
+        assertThat(authData.emailAuthData().authKey()).isEqualTo("key");
+    }
+
+    @Test
+    void shouldBuildTimeoutConfiguration() {
+        var config = new ServerBridgeHandlerConfiguration();
+        config.setTimeout(BigDecimal.valueOf(5));
+        config.setTimeoutMin(BigDecimal.valueOf(3));
+        config.setTimeoutMax(BigDecimal.valueOf(7));
+
+        TimeoutConfiguration timeoutConfiguration = SuplaBridge.buildTimeoutConfiguration(config);
+
+        assertThat(timeoutConfiguration.timeout()).isEqualTo(5);
+        assertThat(timeoutConfiguration.min()).isEqualTo(3);
+        assertThat(timeoutConfiguration.max()).isEqualTo(7);
+    }
+}

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/oh_config/AuthDataTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/oh_config/AuthDataTest.java
@@ -1,0 +1,35 @@
+package pl.grzeslowski.openhab.supla.internal.server.oh_config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class AuthDataTest {
+    @Test
+    void shouldRejectEmptyAuthData() {
+        assertThatThrownBy(() -> new AuthData(null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("AuthData must have at least one value");
+    }
+
+    @Test
+    void shouldKeepLocationAuthData() {
+        var location = new AuthData.LocationAuthData(123, "password");
+
+        var authData = new AuthData(location, null);
+
+        assertThat(authData.locationAuthData()).isEqualTo(location);
+        assertThat(authData.emailAuthData()).isNull();
+    }
+
+    @Test
+    void shouldKeepEmailAuthData() {
+        var email = new AuthData.EmailAuthData("mail@example.com", "key");
+
+        var authData = new AuthData(null, email);
+
+        assertThat(authData.locationAuthData()).isNull();
+        assertThat(authData.emailAuthData()).isEqualTo(email);
+    }
+}

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/traits/DeviceChannelTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/traits/DeviceChannelTest.java
@@ -1,0 +1,101 @@
+package pl.grzeslowski.openhab.supla.internal.server.traits;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+import static pl.grzeslowski.jsupla.protocol.api.ChannelFunction.SUPLA_CHANNELFNC_NONE;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import pl.grzeslowski.jsupla.protocol.api.ChannelFunction;
+import pl.grzeslowski.jsupla.protocol.api.channeltype.value.HvacValue;
+import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelA;
+import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelB;
+import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelE;
+
+@ExtendWith(MockitoExtension.class)
+class DeviceChannelTest {
+    @Mock
+    private SuplaDeviceChannelA channelA;
+
+    @Mock
+    private SuplaDeviceChannelB channelB;
+
+    @Mock
+    private SuplaDeviceChannelE channelE;
+
+    @Mock
+    private HvacValue hvacValue;
+
+    @Test
+    void shouldRejectMissingValues() {
+        assertThatThrownBy(() -> new DeviceChannel(1, 2, SUPLA_CHANNELFNC_NONE, null, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("value and hvacValue must not be null!");
+    }
+
+    @Test
+    void shouldBuildFromProtoA() {
+        byte[] value = new byte[] {0x01, 0x02};
+        when(channelA.number()).thenReturn(5);
+        when(channelA.type()).thenReturn(7);
+        when(channelA.value()).thenReturn(value);
+
+        DeviceChannel deviceChannel = DeviceChannel.fromProto(channelA);
+
+        assertThat(deviceChannel.number()).isEqualTo(5);
+        assertThat(deviceChannel.type()).isEqualTo(7);
+        assertThat(deviceChannel.channelFunction()).isEqualTo(SUPLA_CHANNELFNC_NONE);
+        assertThat(deviceChannel.value()).containsExactly(value);
+        assertThat(deviceChannel.hvacValue()).isNull();
+        assertThat(deviceChannel.subDeviceId()).isNull();
+    }
+
+    @Test
+    void shouldBuildFromProtoBWithChannelFunction() {
+        byte[] value = new byte[] {0x0A};
+        when(channelB.number()).thenReturn(10);
+        when(channelB.type()).thenReturn(20);
+        when(channelB.funcList()).thenReturn(ChannelFunction.SUPLA_CHANNELFNC_NONE.getValue());
+        when(channelB.value()).thenReturn(value);
+
+        DeviceChannel deviceChannel = DeviceChannel.fromProto(channelB);
+
+        assertThat(deviceChannel.number()).isEqualTo(10);
+        assertThat(deviceChannel.type()).isEqualTo(20);
+        assertThat(deviceChannel.channelFunction()).isEqualTo(SUPLA_CHANNELFNC_NONE);
+        assertThat(deviceChannel.value()).containsExactly(value);
+        assertThat(deviceChannel.hvacValue()).isNull();
+        assertThat(deviceChannel.subDeviceId()).isNull();
+    }
+
+    @Test
+    void shouldBuildFromProtoEWithSubDeviceId() {
+        byte[] value = new byte[] {0x0B, 0x0C};
+        when(channelE.number()).thenReturn(11);
+        when(channelE.type()).thenReturn(21);
+        when(channelE.funcList()).thenReturn(ChannelFunction.SUPLA_CHANNELFNC_NONE.getValue());
+        when(channelE.value()).thenReturn(value);
+        when(channelE.hvacValue()).thenReturn(null);
+        when(channelE.subDeviceId()).thenReturn(3L);
+
+        DeviceChannel deviceChannel = DeviceChannel.fromProto(channelE);
+
+        assertThat(deviceChannel.number()).isEqualTo(11);
+        assertThat(deviceChannel.type()).isEqualTo(21);
+        assertThat(deviceChannel.channelFunction()).isEqualTo(SUPLA_CHANNELFNC_NONE);
+        assertThat(deviceChannel.value()).containsExactly(value);
+        assertThat(deviceChannel.hvacValue()).isNull();
+        assertThat(deviceChannel.subDeviceId()).isEqualTo(3);
+    }
+
+    @Test
+    void shouldAcceptHvacWithoutValue() {
+        DeviceChannel deviceChannel = new DeviceChannel(1, 2, SUPLA_CHANNELFNC_NONE, null, hvacValue, null);
+
+        assertThat(deviceChannel.value()).isNull();
+        assertThat(deviceChannel.hvacValue()).isEqualTo(hvacValue);
+    }
+}

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/traits/DeviceChannelValueTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/traits/DeviceChannelValueTest.java
@@ -1,0 +1,69 @@
+package pl.grzeslowski.openhab.supla.internal.server.traits;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelValueA;
+import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelValueB;
+import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelValueC;
+
+@ExtendWith(MockitoExtension.class)
+class DeviceChannelValueTest {
+    @Mock
+    private SuplaDeviceChannelValueA valueA;
+
+    @Mock
+    private SuplaDeviceChannelValueB valueB;
+
+    @Mock
+    private SuplaDeviceChannelValueC valueC;
+
+    @Test
+    void shouldBuildFromProtoA() {
+        byte[] bytes = new byte[] {0x01};
+        when(valueA.channelNumber()).thenReturn(2);
+        when(valueA.value()).thenReturn(bytes);
+
+        DeviceChannelValue deviceChannelValue = DeviceChannelValue.fromProto(valueA);
+
+        assertThat(deviceChannelValue.channelNumber()).isEqualTo(2);
+        assertThat(deviceChannelValue.value()).containsExactly(bytes);
+        assertThat(deviceChannelValue.offline()).isFalse();
+        assertThat(deviceChannelValue.validityTimeSec()).isNull();
+    }
+
+    @Test
+    void shouldBuildFromProtoB() {
+        byte[] bytes = new byte[] {0x02};
+        when(valueB.channelNumber()).thenReturn(3);
+        when(valueB.value()).thenReturn(bytes);
+        when(valueB.offline()).thenReturn((byte) 1);
+
+        DeviceChannelValue deviceChannelValue = DeviceChannelValue.fromProto(valueB);
+
+        assertThat(deviceChannelValue.channelNumber()).isEqualTo(3);
+        assertThat(deviceChannelValue.value()).containsExactly(bytes);
+        assertThat(deviceChannelValue.offline()).isTrue();
+        assertThat(deviceChannelValue.validityTimeSec()).isNull();
+    }
+
+    @Test
+    void shouldBuildFromProtoC() {
+        byte[] bytes = new byte[] {0x03};
+        when(valueC.channelNumber()).thenReturn(4);
+        when(valueC.value()).thenReturn(bytes);
+        when(valueC.offline()).thenReturn((byte) 0);
+        when(valueC.validityTimeSec()).thenReturn(99L);
+
+        DeviceChannelValue deviceChannelValue = DeviceChannelValue.fromProto(valueC);
+
+        assertThat(deviceChannelValue.channelNumber()).isEqualTo(4);
+        assertThat(deviceChannelValue.value()).containsExactly(bytes);
+        assertThat(deviceChannelValue.offline()).isFalse();
+        assertThat(deviceChannelValue.validityTimeSec()).isEqualTo(99L);
+    }
+}

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/traits/FlagsTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/traits/FlagsTest.java
@@ -1,0 +1,59 @@
+package pl.grzeslowski.openhab.supla.internal.server.traits;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static pl.grzeslowski.jsupla.protocol.api.consts.ProtoConsts.SUPLA_DEVICE_FLAG_ALWAYS_ALLOW_CHANNEL_DELETION;
+import static pl.grzeslowski.jsupla.protocol.api.consts.ProtoConsts.SUPLA_DEVICE_FLAG_CALCFG_ENTER_CFG_MODE;
+import static pl.grzeslowski.jsupla.protocol.api.consts.ProtoConsts.SUPLA_DEVICE_FLAG_CALCFG_IDENTIFY_DEVICE;
+import static pl.grzeslowski.jsupla.protocol.api.consts.ProtoConsts.SUPLA_DEVICE_FLAG_CALCFG_RESTART_DEVICE;
+import static pl.grzeslowski.jsupla.protocol.api.consts.ProtoConsts.SUPLA_DEVICE_FLAG_CALCFG_SET_TIME;
+import static pl.grzeslowski.jsupla.protocol.api.consts.ProtoConsts.SUPLA_DEVICE_FLAG_CALCFG_SUBDEVICE_PAIRING;
+import static pl.grzeslowski.jsupla.protocol.api.consts.ProtoConsts.SUPLA_DEVICE_FLAG_DEVICE_CONFIG_SUPPORTED;
+import static pl.grzeslowski.jsupla.protocol.api.consts.ProtoConsts.SUPLA_DEVICE_FLAG_DEVICE_LOCKED;
+import static pl.grzeslowski.jsupla.protocol.api.consts.ProtoConsts.SUPLA_DEVICE_FLAG_SLEEP_MODE_ENABLED;
+
+import org.junit.jupiter.api.Test;
+
+class FlagsTest {
+    @Test
+    void shouldSetAllFlags() {
+        int combined =
+                SUPLA_DEVICE_FLAG_CALCFG_ENTER_CFG_MODE
+                        | SUPLA_DEVICE_FLAG_SLEEP_MODE_ENABLED
+                        | SUPLA_DEVICE_FLAG_CALCFG_SET_TIME
+                        | SUPLA_DEVICE_FLAG_DEVICE_CONFIG_SUPPORTED
+                        | SUPLA_DEVICE_FLAG_DEVICE_LOCKED
+                        | SUPLA_DEVICE_FLAG_CALCFG_SUBDEVICE_PAIRING
+                        | SUPLA_DEVICE_FLAG_CALCFG_IDENTIFY_DEVICE
+                        | SUPLA_DEVICE_FLAG_CALCFG_RESTART_DEVICE
+                        | SUPLA_DEVICE_FLAG_ALWAYS_ALLOW_CHANNEL_DELETION;
+
+        Flags flags = new Flags(combined);
+
+        assertThat(flags.calcfgEnterCfgMode()).isTrue();
+        assertThat(flags.sleepModeEnabled()).isTrue();
+        assertThat(flags.calcfgSetTime()).isTrue();
+        assertThat(flags.deviceConfigSupported()).isTrue();
+        assertThat(flags.deviceLocked()).isTrue();
+        assertThat(flags.calcfgSubdevicePairing()).isTrue();
+        assertThat(flags.calcfgIdentifyDevice()).isTrue();
+        assertThat(flags.calcfgRestartDevice()).isTrue();
+        assertThat(flags.alwaysAllowChannelDeletion()).isTrue();
+        assertThat(flags.suplaDeviceFlagBlockAddingChannelsAfterDeletion()).isFalse();
+    }
+
+    @Test
+    void shouldDefaultAllFlagsToFalse() {
+        Flags flags = new Flags(0);
+
+        assertThat(flags.calcfgEnterCfgMode()).isFalse();
+        assertThat(flags.sleepModeEnabled()).isFalse();
+        assertThat(flags.calcfgSetTime()).isFalse();
+        assertThat(flags.deviceConfigSupported()).isFalse();
+        assertThat(flags.deviceLocked()).isFalse();
+        assertThat(flags.calcfgSubdevicePairing()).isFalse();
+        assertThat(flags.calcfgIdentifyDevice()).isFalse();
+        assertThat(flags.calcfgRestartDevice()).isFalse();
+        assertThat(flags.alwaysAllowChannelDeletion()).isFalse();
+        assertThat(flags.suplaDeviceFlagBlockAddingChannelsAfterDeletion()).isFalse();
+    }
+}

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/traits/RegisterDeviceTraitTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/traits/RegisterDeviceTraitTest.java
@@ -1,0 +1,116 @@
+package pl.grzeslowski.openhab.supla.internal.server.traits;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static pl.grzeslowski.jsupla.protocol.api.ProtocolHelpers.parseHexString;
+import static pl.grzeslowski.jsupla.protocol.api.ProtocolHelpers.parseString;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaRegisterDeviceA;
+import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaRegisterDeviceD;
+import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaRegisterDeviceE;
+import pl.grzeslowski.jsupla.protocol.api.types.ToServerProto;
+
+@ExtendWith(MockitoExtension.class)
+class RegisterDeviceTraitTest {
+    private static final byte[] GUID = new byte[] {0x01, 0x02, 0x03, 0x04};
+    private static final byte[] NAME = "Test Device".getBytes();
+    private static final byte[] SOFT_VER = "1.0".getBytes();
+
+    @Mock
+    private ToServerProto toServerProto;
+
+    @Mock
+    private SuplaRegisterDeviceA registerDeviceA;
+
+    @Mock
+    private SuplaRegisterDeviceD registerDeviceD;
+
+    @Mock
+    private SuplaRegisterDeviceE registerDeviceE;
+
+    @Test
+    void shouldReturnEmptyOptionalWhenNotRegisterDevice() {
+        Optional<RegisterDeviceTrait> result = RegisterDeviceTrait.fromProto(toServerProto);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldMapRegisterDeviceAToLocationTrait() {
+        byte[] locationPassword = new byte[] {0x0A};
+        when(registerDeviceA.guid()).thenReturn(GUID);
+        when(registerDeviceA.name()).thenReturn(NAME);
+        when(registerDeviceA.softVer()).thenReturn(SOFT_VER);
+        when(registerDeviceA.channels()).thenReturn(new pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelA[0]);
+        when(registerDeviceA.locationId()).thenReturn(5);
+        when(registerDeviceA.locationPwd()).thenReturn(locationPassword);
+
+        RegisterDeviceTrait trait = RegisterDeviceTrait.fromProto(registerDeviceA);
+
+        assertThat(trait).isInstanceOf(RegisterLocationDeviceTrait.class);
+        RegisterLocationDeviceTrait locationTrait = (RegisterLocationDeviceTrait) trait;
+        assertThat(locationTrait.guid()).isEqualTo(parseHexString(GUID));
+        assertThat(locationTrait.name()).isEqualTo(parseString(NAME));
+        assertThat(locationTrait.softVer()).isEqualTo(parseString(SOFT_VER));
+        assertThat(locationTrait.manufacturerId()).isNull();
+        assertThat(locationTrait.productId()).isNull();
+        assertThat(locationTrait.channels()).isEmpty();
+        assertThat(locationTrait.locationId()).isEqualTo(5);
+        assertThat(locationTrait.locationPwd()).containsExactly(locationPassword);
+    }
+
+    @Test
+    void shouldMapRegisterDeviceDToEmailTrait() {
+        byte[] authKey = new byte[] {0x01, 0x02};
+        when(registerDeviceD.guid()).thenReturn(GUID);
+        when(registerDeviceD.name()).thenReturn(NAME);
+        when(registerDeviceD.softVer()).thenReturn(SOFT_VER);
+        when(registerDeviceD.channels()).thenReturn(new pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelE[0]);
+        when(registerDeviceD.email()).thenReturn("user@example.com".getBytes());
+        when(registerDeviceD.authKey()).thenReturn(authKey);
+        when(registerDeviceD.serverName()).thenReturn("server.supla.org".getBytes());
+
+        RegisterDeviceTrait trait = RegisterDeviceTrait.fromProto(registerDeviceD);
+
+        assertThat(trait).isInstanceOf(RegisterEmailDeviceTrait.class);
+        RegisterEmailDeviceTrait emailTrait = (RegisterEmailDeviceTrait) trait;
+        assertThat(emailTrait.guid()).isEqualTo(parseHexString(GUID));
+        assertThat(emailTrait.name()).isEqualTo(parseString(NAME));
+        assertThat(emailTrait.softVer()).isEqualTo(parseString(SOFT_VER));
+        assertThat(emailTrait.manufacturerId()).isNull();
+        assertThat(emailTrait.productId()).isNull();
+        assertThat(emailTrait.channels()).isEmpty();
+        assertThat(emailTrait.email()).isEqualTo("user@example.com");
+        assertThat(emailTrait.authKey()).containsExactly(authKey);
+        assertThat(emailTrait.serverName()).isEqualTo("server.supla.org");
+    }
+
+    @Test
+    void shouldMapRegisterDeviceEWithManufacturerAndProduct() {
+        byte[] authKey = new byte[] {0x05};
+        when(registerDeviceE.guid()).thenReturn(GUID);
+        when(registerDeviceE.name()).thenReturn(NAME);
+        when(registerDeviceE.softVer()).thenReturn(SOFT_VER);
+        when(registerDeviceE.channels()).thenReturn(new pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelE[0]);
+        when(registerDeviceE.manufacturerId()).thenReturn(10L);
+        when(registerDeviceE.productId()).thenReturn(20L);
+        when(registerDeviceE.email()).thenReturn("another@example.com".getBytes());
+        when(registerDeviceE.authKey()).thenReturn(authKey);
+        when(registerDeviceE.serverName()).thenReturn("prod.server".getBytes());
+
+        RegisterDeviceTrait trait = RegisterDeviceTrait.fromProto(registerDeviceE);
+
+        assertThat(trait).isInstanceOf(RegisterEmailDeviceTrait.class);
+        RegisterEmailDeviceTrait emailTrait = (RegisterEmailDeviceTrait) trait;
+        assertThat(emailTrait.manufacturerId()).isEqualTo(10);
+        assertThat(emailTrait.productId()).isEqualTo(20);
+        assertThat(emailTrait.email()).isEqualTo("another@example.com");
+        assertThat(emailTrait.authKey()).containsExactly(authKey);
+        assertThat(emailTrait.serverName()).isEqualTo("prod.server");
+    }
+}

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
## Summary
- switch ChannelUtilTest, HandlerCommandTraitTest, and InMemoryStateCacheTest to use @InjectMocks for class construction
- keep Mockito-based setup while avoiding manual instantiation in favor of injected test subjects

## Testing
- mvn -q test *(fails: unable to resolve biz.aQute.bnd:bnd-maven-plugin due to 403 from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691edb302fc88320adcb9303c79b64c5)