### PR TITLE
Add PlantUML diagram for handler inheritance hierarchy

### DIFF
--- a/imgs/handler-inheritance.puml
+++ b/imgs/handler-inheritance.puml
@@ -14,6 +14,12 @@ abstract class BaseThingHandler <<OpenHAB>>
 abstract class BaseBridgeHandler <<OpenHAB>>
 
 ' Device handler hierarchy
+interface HandleCommand <<Supla>>
+interface HandleProto <<Supla>>
+interface SuplaDevice <<Supla>>
+interface SuplaThing <<Supla>>
+interface SuplaThingRegistry <<Supla>>
+interface SuplaBridge <<Supla>>
 abstract class AbstractDeviceHandler <<Supla>>
 abstract class ServerAbstractDeviceHandler <<Supla>>
 class GatewayDeviceHandler <<Supla>>
@@ -32,9 +38,26 @@ ServerAbstractDeviceHandler <|-- GatewayDeviceHandler
 ServerAbstractDeviceHandler <|-- SingleDeviceHandler
 AbstractDeviceHandler <|-- SubDeviceHandler
 AbstractDeviceHandler <|-- CloudDeviceHandler
+HandleCommand <|.. AbstractDeviceHandler
+HandleCommand <|.. SubDeviceHandler
+HandleCommand <|.. SingleDeviceHandler
+HandleCommand <|.. GatewayDeviceHandler
+HandleProto <|.. ServerAbstractDeviceHandler
+HandleProto <|.. SingleDeviceHandler
+HandleProto <|.. GatewayDeviceHandler
+HandleCommand <|-- SuplaDevice
+HandleProto <|-- SuplaDevice
+SuplaDevice <|.. SubDeviceHandler
+SuplaDevice <|.. SingleDeviceHandler
+SuplaDevice <|.. GatewayDeviceHandler
 
 ThingHandler <|.. BridgeHandler
 BridgeHandler <|.. BaseBridgeHandler
 BaseBridgeHandler <|-- CloudBridgeHandler
 BaseBridgeHandler <|-- ServerBridgeHandler
+BridgeHandler <|.. SuplaBridge
+SuplaBridge <|.. GatewayDeviceHandler
+SuplaBridge <|.. ServerBridgeHandler
+SuplaThing <|.. ServerAbstractDeviceHandler
+SuplaThingRegistry <|.. ServerBridgeHandler
 @enduml

--- a/imgs/handler-inheritance.puml
+++ b/imgs/handler-inheritance.puml
@@ -1,0 +1,35 @@
+@startuml
+skinparam classAttributeIconSize 0
+skinparam linetype ortho
+
+' OpenHAB core abstractions
+interface ThingHandler
+interface BridgeHandler
+abstract class BaseThingHandler
+abstract class BaseBridgeHandler
+
+' Device handler hierarchy
+abstract class AbstractDeviceHandler
+abstract class ServerAbstractDeviceHandler
+class GatewayDeviceHandler
+class SingleDeviceHandler
+class SubDeviceHandler
+class CloudDeviceHandler
+
+' Bridge handler hierarchy
+class CloudBridgeHandler
+class ServerBridgeHandler
+
+ThingHandler <|.. BaseThingHandler
+BaseThingHandler <|-- AbstractDeviceHandler
+AbstractDeviceHandler <|-- ServerAbstractDeviceHandler
+ServerAbstractDeviceHandler <|-- GatewayDeviceHandler
+ServerAbstractDeviceHandler <|-- SingleDeviceHandler
+AbstractDeviceHandler <|-- SubDeviceHandler
+AbstractDeviceHandler <|-- CloudDeviceHandler
+
+ThingHandler <|.. BridgeHandler
+BridgeHandler <|.. BaseBridgeHandler
+BaseBridgeHandler <|-- CloudBridgeHandler
+BaseBridgeHandler <|-- ServerBridgeHandler
+@enduml

--- a/imgs/handler-inheritance.puml
+++ b/imgs/handler-inheritance.puml
@@ -2,6 +2,7 @@
 skinparam classAttributeIconSize 0
 skinparam linetype ortho
 
+' Keep the most-shared abstractions visually at the top
 top to bottom direction
 
 skinparam class {
@@ -9,19 +10,19 @@ skinparam class {
   BackgroundColor<<Supla>> Cornsilk
 }
 
-' Core OpenHAB abstractions (kept at the top)
-interface ThingHandler <<OpenHAB>>
-interface BridgeHandler <<OpenHAB>>
-abstract class BaseThingHandler <<OpenHAB>>
-abstract class BaseBridgeHandler <<OpenHAB>>
-
-' Supla traits and shared interfaces
-interface HandleCommand <<Supla>>
-interface HandleProto <<Supla>>
-interface SuplaDevice <<Supla>>
-interface SuplaThing <<Supla>>
-interface SuplaThingRegistry <<Supla>>
-interface SuplaBridge <<Supla>>
+' Anchor heavily used OpenHAB and Supla abstractions on the top rank
+together {
+  interface ThingHandler <<OpenHAB>>
+  interface BridgeHandler <<OpenHAB>>
+  abstract class BaseThingHandler <<OpenHAB>>
+  abstract class BaseBridgeHandler <<OpenHAB>>
+  interface HandleCommand <<Supla>>
+  interface HandleProto <<Supla>>
+  interface SuplaDevice <<Supla>>
+  interface SuplaThing <<Supla>>
+  interface SuplaThingRegistry <<Supla>>
+  interface SuplaBridge <<Supla>>
+}
 
 ' Device handler hierarchy
 abstract class AbstractDeviceHandler <<Supla>>

--- a/imgs/handler-inheritance.puml
+++ b/imgs/handler-inheritance.puml
@@ -2,23 +2,28 @@
 skinparam classAttributeIconSize 0
 skinparam linetype ortho
 
+skinparam class {
+  BackgroundColor<<OpenHAB>> HoneyDew
+  BackgroundColor<<Supla>> Cornsilk
+}
+
 ' OpenHAB core abstractions
-interface ThingHandler
-interface BridgeHandler
-abstract class BaseThingHandler
-abstract class BaseBridgeHandler
+interface ThingHandler <<OpenHAB>>
+interface BridgeHandler <<OpenHAB>>
+abstract class BaseThingHandler <<OpenHAB>>
+abstract class BaseBridgeHandler <<OpenHAB>>
 
 ' Device handler hierarchy
-abstract class AbstractDeviceHandler
-abstract class ServerAbstractDeviceHandler
-class GatewayDeviceHandler
-class SingleDeviceHandler
-class SubDeviceHandler
-class CloudDeviceHandler
+abstract class AbstractDeviceHandler <<Supla>>
+abstract class ServerAbstractDeviceHandler <<Supla>>
+class GatewayDeviceHandler <<Supla>>
+class SingleDeviceHandler <<Supla>>
+class SubDeviceHandler <<Supla>>
+class CloudDeviceHandler <<Supla>>
 
 ' Bridge handler hierarchy
-class CloudBridgeHandler
-class ServerBridgeHandler
+class CloudBridgeHandler <<Supla>>
+class ServerBridgeHandler <<Supla>>
 
 ThingHandler <|.. BaseThingHandler
 BaseThingHandler <|-- AbstractDeviceHandler

--- a/imgs/handler-inheritance.puml
+++ b/imgs/handler-inheritance.puml
@@ -1,6 +1,9 @@
 @startuml
 skinparam classAttributeIconSize 0
 skinparam linetype ortho
+skinparam nodesep 60
+skinparam ranksep 60
+hide empty members
 
 ' Keep the most-shared abstractions visually at the top
 top to bottom direction
@@ -11,30 +14,39 @@ skinparam class {
 }
 
 ' Anchor heavily used OpenHAB and Supla abstractions on the top rank
-together {
-  interface ThingHandler <<OpenHAB>>
-  interface BridgeHandler <<OpenHAB>>
-  abstract class BaseThingHandler <<OpenHAB>>
-  abstract class BaseBridgeHandler <<OpenHAB>>
-  interface HandleCommand <<Supla>>
-  interface HandleProto <<Supla>>
-  interface SuplaDevice <<Supla>>
-  interface SuplaThing <<Supla>>
-  interface SuplaThingRegistry <<Supla>>
-  interface SuplaBridge <<Supla>>
+rectangle "Shared abstractions" as Shared {
+  together {
+    package "OpenHAB Core" {
+      interface ThingHandler <<OpenHAB>>
+      interface BridgeHandler <<OpenHAB>>
+      abstract class BaseThingHandler <<OpenHAB>>
+      abstract class BaseBridgeHandler <<OpenHAB>>
+    }
+
+    package "Supla Traits" {
+      interface HandleCommand <<Supla>>
+      interface HandleProto <<Supla>>
+      interface SuplaDevice <<Supla>>
+      interface SuplaThing <<Supla>>
+      interface SuplaThingRegistry <<Supla>>
+      interface SuplaBridge <<Supla>>
+    }
+  }
 }
 
-' Device handler hierarchy
-abstract class AbstractDeviceHandler <<Supla>>
-abstract class ServerAbstractDeviceHandler <<Supla>>
-class GatewayDeviceHandler <<Supla>>
-class SingleDeviceHandler <<Supla>>
-class SubDeviceHandler <<Supla>>
-class CloudDeviceHandler <<Supla>>
+package "Device handlers" {
+  abstract class AbstractDeviceHandler <<Supla>>
+  abstract class ServerAbstractDeviceHandler <<Supla>>
+  class GatewayDeviceHandler <<Supla>>
+  class SingleDeviceHandler <<Supla>>
+  class SubDeviceHandler <<Supla>>
+  class CloudDeviceHandler <<Supla>>
+}
 
-' Bridge handler hierarchy
-class CloudBridgeHandler <<Supla>>
-class ServerBridgeHandler <<Supla>>
+package "Bridge handlers" {
+  class CloudBridgeHandler <<Supla>>
+  class ServerBridgeHandler <<Supla>>
+}
 
 ' OpenHAB core relationships
 ThingHandler <|.. BaseThingHandler

--- a/imgs/handler-inheritance.puml
+++ b/imgs/handler-inheritance.puml
@@ -2,24 +2,28 @@
 skinparam classAttributeIconSize 0
 skinparam linetype ortho
 
+top to bottom direction
+
 skinparam class {
   BackgroundColor<<OpenHAB>> HoneyDew
   BackgroundColor<<Supla>> Cornsilk
 }
 
-' OpenHAB core abstractions
+' Core OpenHAB abstractions (kept at the top)
 interface ThingHandler <<OpenHAB>>
 interface BridgeHandler <<OpenHAB>>
 abstract class BaseThingHandler <<OpenHAB>>
 abstract class BaseBridgeHandler <<OpenHAB>>
 
-' Device handler hierarchy
+' Supla traits and shared interfaces
 interface HandleCommand <<Supla>>
 interface HandleProto <<Supla>>
 interface SuplaDevice <<Supla>>
 interface SuplaThing <<Supla>>
 interface SuplaThingRegistry <<Supla>>
 interface SuplaBridge <<Supla>>
+
+' Device handler hierarchy
 abstract class AbstractDeviceHandler <<Supla>>
 abstract class ServerAbstractDeviceHandler <<Supla>>
 class GatewayDeviceHandler <<Supla>>
@@ -31,13 +35,20 @@ class CloudDeviceHandler <<Supla>>
 class CloudBridgeHandler <<Supla>>
 class ServerBridgeHandler <<Supla>>
 
+' OpenHAB core relationships
 ThingHandler <|.. BaseThingHandler
+ThingHandler <|.. BridgeHandler
+BridgeHandler <|.. BaseBridgeHandler
+
+' Device handler relationships
 BaseThingHandler <|-- AbstractDeviceHandler
 AbstractDeviceHandler <|-- ServerAbstractDeviceHandler
-ServerAbstractDeviceHandler <|-- GatewayDeviceHandler
-ServerAbstractDeviceHandler <|-- SingleDeviceHandler
 AbstractDeviceHandler <|-- SubDeviceHandler
 AbstractDeviceHandler <|-- CloudDeviceHandler
+ServerAbstractDeviceHandler <|-- GatewayDeviceHandler
+ServerAbstractDeviceHandler <|-- SingleDeviceHandler
+
+' Supla trait implementations (device side)
 HandleCommand <|.. AbstractDeviceHandler
 HandleCommand <|.. SubDeviceHandler
 HandleCommand <|.. SingleDeviceHandler
@@ -50,14 +61,13 @@ HandleProto <|-- SuplaDevice
 SuplaDevice <|.. SubDeviceHandler
 SuplaDevice <|.. SingleDeviceHandler
 SuplaDevice <|.. GatewayDeviceHandler
+SuplaThing <|.. ServerAbstractDeviceHandler
 
-ThingHandler <|.. BridgeHandler
-BridgeHandler <|.. BaseBridgeHandler
+' Bridge handler relationships
 BaseBridgeHandler <|-- CloudBridgeHandler
 BaseBridgeHandler <|-- ServerBridgeHandler
 BridgeHandler <|.. SuplaBridge
 SuplaBridge <|.. GatewayDeviceHandler
 SuplaBridge <|.. ServerBridgeHandler
-SuplaThing <|.. ServerAbstractDeviceHandler
 SuplaThingRegistry <|.. ServerBridgeHandler
 @enduml


### PR DESCRIPTION
## Summary
- add a PlantUML diagram describing the inheritance relationships for device and bridge handler classes

## Testing
- not run (not needed)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691eede57c808320abc6874fc4d45491)