### PR TITLE
Use protocol record instances in tests

### DIFF
--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/ChannelUtilTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/ChannelUtilTest.java
@@ -115,10 +115,8 @@ class ChannelUtilTest {
         var channelUID = new ChannelUID("supla:test:1:1");
         map.put(5, new SuplaDevice.ChannelAndPreviousState(channelUID, null));
         when(suplaDevice.getSenderIdToChannelUID()).thenReturn(map);
-        var newValueResult = org.mockito.Mockito.mock(
-                pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaChannelNewValueResult.class);
-        when(newValueResult.senderId()).thenReturn(5);
-        when(newValueResult.success()).thenReturn((byte) 1);
+        var newValueResult =
+                new pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaChannelNewValueResult((short) 0, 5, (byte) 1);
 
         channelUtil.consumeSuplaChannelNewValueResult(newValueResult);
 
@@ -134,11 +132,8 @@ class ChannelUtilTest {
         var channel = org.mockito.Mockito.mock(Channel.class);
         when(channel.getUID()).thenReturn(channelUID);
         when(thing.getChannels()).thenReturn(new ArrayList<>(java.util.List.of(channel)));
-        var newValueResult = org.mockito.Mockito.mock(
-                pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaChannelNewValueResult.class);
-        when(newValueResult.senderId()).thenReturn(8);
-        when(newValueResult.channelNumber()).thenReturn((short) 2);
-        when(newValueResult.success()).thenReturn((byte) 0);
+        var newValueResult =
+                new pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaChannelNewValueResult((short) 2, 8, (byte) 0);
 
         channelUtil.consumeSuplaChannelNewValueResult(newValueResult);
 

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/cache/InMemoryStateCacheTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/cache/InMemoryStateCacheTest.java
@@ -22,7 +22,7 @@ class InMemoryStateCacheTest {
 
     @Test
     void shouldStoreAndReturnState() {
-        ChannelUID channelUID = new ChannelUID("binding:thing:1");
+        ChannelUID channelUID = new ChannelUID("binding:thing:1:channel");
         State state = new State() {
             @Override
             public <T extends State> T as(Class<T> type) {
@@ -50,7 +50,7 @@ class InMemoryStateCacheTest {
 
     @Test
     void shouldAllowNullState() {
-        ChannelUID channelUID = new ChannelUID("binding:thing:2");
+        ChannelUID channelUID = new ChannelUID("binding:thing:2:channel");
 
         cache.saveState(channelUID, null);
         var found = cache.findState(channelUID);

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/traits/DeviceChannelTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/traits/DeviceChannelTest.java
@@ -2,7 +2,6 @@ package pl.grzeslowski.openhab.supla.internal.server.traits;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
 import static pl.grzeslowski.jsupla.protocol.api.ChannelFunction.SUPLA_CHANNELFNC_NONE;
 
 import org.junit.jupiter.api.Test;
@@ -21,7 +20,7 @@ class DeviceChannelTest {
 
     @Test
     void shouldBuildFromProtoA() {
-        byte[] value = new byte[] {0x01, 0x02};
+        byte[] value = new byte[] {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
         SuplaDeviceChannelA channelA = new SuplaDeviceChannelA((short) 5, 7, value);
 
         DeviceChannel deviceChannel = DeviceChannel.fromProto(channelA);
@@ -36,7 +35,7 @@ class DeviceChannelTest {
 
     @Test
     void shouldBuildFromProtoBWithChannelFunction() {
-        byte[] value = new byte[] {0x0A};
+        byte[] value = new byte[] {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x0A};
         SuplaDeviceChannelB channelB =
                 new SuplaDeviceChannelB((short) 10, 20, SUPLA_CHANNELFNC_NONE.getValue(), 0, value);
 
@@ -52,7 +51,7 @@ class DeviceChannelTest {
 
     @Test
     void shouldBuildFromProtoEWithSubDeviceId() {
-        byte[] value = new byte[] {0x0B, 0x0C};
+        byte[] value = new byte[] {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x0B, 0x0C};
         SuplaDeviceChannelE channelE = new SuplaDeviceChannelE(
                 (short) 11,
                 21,
@@ -80,7 +79,13 @@ class DeviceChannelTest {
 
     @Test
     void shouldAcceptHvacWithoutValue() {
-        HvacValue hvacValue = mock(HvacValue.class);
+        HvacValue hvacValue = new HvacValue(
+                true,
+                HvacValue.Mode.NOT_SET,
+                null,
+                null,
+                new HvacValue.Flags(
+                        false, false, false, false, false, false, false, false, false, false, false, false, false));
         DeviceChannel deviceChannel = new DeviceChannel(1, 2, SUPLA_CHANNELFNC_NONE, null, hvacValue, null);
 
         assertThat(deviceChannel.value()).isNull();

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/traits/DeviceChannelTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/traits/DeviceChannelTest.java
@@ -2,32 +2,16 @@ package pl.grzeslowski.openhab.supla.internal.server.traits;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
 import static pl.grzeslowski.jsupla.protocol.api.ChannelFunction.SUPLA_CHANNELFNC_NONE;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.HvacValue;
 import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelA;
 import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelB;
 import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelE;
 
-@ExtendWith(MockitoExtension.class)
 class DeviceChannelTest {
-    @Mock
-    private SuplaDeviceChannelA channelA;
-
-    @Mock
-    private SuplaDeviceChannelB channelB;
-
-    @Mock
-    private SuplaDeviceChannelE channelE;
-
-    @Mock
-    private HvacValue hvacValue;
-
     @Test
     void shouldRejectMissingValues() {
         assertThatThrownBy(() -> new DeviceChannel(1, 2, SUPLA_CHANNELFNC_NONE, null, null, null))
@@ -38,9 +22,7 @@ class DeviceChannelTest {
     @Test
     void shouldBuildFromProtoA() {
         byte[] value = new byte[] {0x01, 0x02};
-        when(channelA.number()).thenReturn((short) 5);
-        when(channelA.type()).thenReturn(7);
-        when(channelA.value()).thenReturn(value);
+        SuplaDeviceChannelA channelA = new SuplaDeviceChannelA((short) 5, 7, value);
 
         DeviceChannel deviceChannel = DeviceChannel.fromProto(channelA);
 
@@ -55,10 +37,8 @@ class DeviceChannelTest {
     @Test
     void shouldBuildFromProtoBWithChannelFunction() {
         byte[] value = new byte[] {0x0A};
-        when(channelB.number()).thenReturn((short) 10);
-        when(channelB.type()).thenReturn(20);
-        when(channelB.funcList()).thenReturn(SUPLA_CHANNELFNC_NONE.getValue());
-        when(channelB.value()).thenReturn(value);
+        SuplaDeviceChannelB channelB =
+                new SuplaDeviceChannelB((short) 10, 20, SUPLA_CHANNELFNC_NONE.getValue(), 0, value);
 
         DeviceChannel deviceChannel = DeviceChannel.fromProto(channelB);
 
@@ -73,12 +53,20 @@ class DeviceChannelTest {
     @Test
     void shouldBuildFromProtoEWithSubDeviceId() {
         byte[] value = new byte[] {0x0B, 0x0C};
-        when(channelE.number()).thenReturn((short) 11);
-        when(channelE.type()).thenReturn(21);
-        when(channelE.funcList()).thenReturn(SUPLA_CHANNELFNC_NONE.getValue());
-        when(channelE.value()).thenReturn(value);
-        when(channelE.hvacValue()).thenReturn(null);
-        when(channelE.subDeviceId()).thenReturn((short) 3);
+        SuplaDeviceChannelE channelE = new SuplaDeviceChannelE(
+                (short) 11,
+                21,
+                SUPLA_CHANNELFNC_NONE.getValue(),
+                null,
+                0,
+                0,
+                (short) 0,
+                0,
+                value,
+                null,
+                null,
+                (short) 0,
+                (short) 3);
 
         DeviceChannel deviceChannel = DeviceChannel.fromProto(channelE);
 
@@ -92,6 +80,7 @@ class DeviceChannelTest {
 
     @Test
     void shouldAcceptHvacWithoutValue() {
+        HvacValue hvacValue = mock(HvacValue.class);
         DeviceChannel deviceChannel = new DeviceChannel(1, 2, SUPLA_CHANNELFNC_NONE, null, hvacValue, null);
 
         assertThat(deviceChannel.value()).isNull();

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/traits/DeviceChannelValueTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/traits/DeviceChannelValueTest.java
@@ -1,32 +1,17 @@
 package pl.grzeslowski.openhab.supla.internal.server.traits;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelValueA;
 import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelValueB;
 import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelValueC;
 
-@ExtendWith(MockitoExtension.class)
 class DeviceChannelValueTest {
-    @Mock
-    private SuplaDeviceChannelValueA valueA;
-
-    @Mock
-    private SuplaDeviceChannelValueB valueB;
-
-    @Mock
-    private SuplaDeviceChannelValueC valueC;
-
     @Test
     void shouldBuildFromProtoA() {
         byte[] bytes = new byte[] {0x01};
-        when(valueA.channelNumber()).thenReturn((short) 2);
-        when(valueA.value()).thenReturn(bytes);
+        SuplaDeviceChannelValueA valueA = new SuplaDeviceChannelValueA((short) 2, bytes);
 
         DeviceChannelValue deviceChannelValue = DeviceChannelValue.fromProto(valueA);
 
@@ -39,9 +24,7 @@ class DeviceChannelValueTest {
     @Test
     void shouldBuildFromProtoB() {
         byte[] bytes = new byte[] {0x02};
-        when(valueB.channelNumber()).thenReturn((short) 3);
-        when(valueB.value()).thenReturn(bytes);
-        when(valueB.offline()).thenReturn((short) 1);
+        SuplaDeviceChannelValueB valueB = new SuplaDeviceChannelValueB((short) 3, (short) 1, bytes);
 
         DeviceChannelValue deviceChannelValue = DeviceChannelValue.fromProto(valueB);
 
@@ -54,10 +37,7 @@ class DeviceChannelValueTest {
     @Test
     void shouldBuildFromProtoC() {
         byte[] bytes = new byte[] {0x03};
-        when(valueC.channelNumber()).thenReturn((short) 4);
-        when(valueC.value()).thenReturn(bytes);
-        when(valueC.offline()).thenReturn((short) 0);
-        when(valueC.validityTimeSec()).thenReturn(99L);
+        SuplaDeviceChannelValueC valueC = new SuplaDeviceChannelValueC((short) 4, (short) 0, 99L, bytes);
 
         DeviceChannelValue deviceChannelValue = DeviceChannelValue.fromProto(valueC);
 

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/traits/DeviceChannelValueTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/traits/DeviceChannelValueTest.java
@@ -10,7 +10,7 @@ import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelValueC;
 class DeviceChannelValueTest {
     @Test
     void shouldBuildFromProtoA() {
-        byte[] bytes = new byte[] {0x01};
+        byte[] bytes = new byte[] {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
         SuplaDeviceChannelValueA valueA = new SuplaDeviceChannelValueA((short) 2, bytes);
 
         DeviceChannelValue deviceChannelValue = DeviceChannelValue.fromProto(valueA);
@@ -23,7 +23,7 @@ class DeviceChannelValueTest {
 
     @Test
     void shouldBuildFromProtoB() {
-        byte[] bytes = new byte[] {0x02};
+        byte[] bytes = new byte[] {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x02};
         SuplaDeviceChannelValueB valueB = new SuplaDeviceChannelValueB((short) 3, (short) 1, bytes);
 
         DeviceChannelValue deviceChannelValue = DeviceChannelValue.fromProto(valueB);
@@ -36,7 +36,7 @@ class DeviceChannelValueTest {
 
     @Test
     void shouldBuildFromProtoC() {
-        byte[] bytes = new byte[] {0x03};
+        byte[] bytes = new byte[] {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x03};
         SuplaDeviceChannelValueC valueC = new SuplaDeviceChannelValueC((short) 4, (short) 0, 99L, bytes);
 
         DeviceChannelValue deviceChannelValue = DeviceChannelValue.fromProto(valueC);

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/traits/RegisterDeviceTraitTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/traits/RegisterDeviceTraitTest.java
@@ -1,37 +1,22 @@
 package pl.grzeslowski.openhab.supla.internal.server.traits;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 import static pl.grzeslowski.jsupla.protocol.api.ProtocolHelpers.parseHexString;
 import static pl.grzeslowski.jsupla.protocol.api.ProtocolHelpers.parseString;
 
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaRegisterDeviceA;
 import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaRegisterDeviceD;
 import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaRegisterDeviceE;
 import pl.grzeslowski.jsupla.protocol.api.types.ToServerProto;
 
-@ExtendWith(MockitoExtension.class)
 class RegisterDeviceTraitTest {
     private static final byte[] GUID = new byte[] {0x01, 0x02, 0x03, 0x04};
     private static final byte[] NAME = "Test Device".getBytes();
     private static final byte[] SOFT_VER = "1.0".getBytes();
 
-    @Mock
-    private ToServerProto toServerProto;
-
-    @Mock
-    private SuplaRegisterDeviceA registerDeviceA;
-
-    @Mock
-    private SuplaRegisterDeviceD registerDeviceD;
-
-    @Mock
-    private SuplaRegisterDeviceE registerDeviceE;
+    private final ToServerProto toServerProto = new ToServerProto() {};
 
     @Test
     void shouldReturnEmptyOptionalWhenNotRegisterDevice() {
@@ -43,13 +28,14 @@ class RegisterDeviceTraitTest {
     @Test
     void shouldMapRegisterDeviceAToLocationTrait() {
         byte[] locationPassword = new byte[] {0x0A};
-        when(registerDeviceA.guid()).thenReturn(GUID);
-        when(registerDeviceA.name()).thenReturn(NAME);
-        when(registerDeviceA.softVer()).thenReturn(SOFT_VER);
-        when(registerDeviceA.channels())
-                .thenReturn(new pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelA[0]);
-        when(registerDeviceA.locationId()).thenReturn(5);
-        when(registerDeviceA.locationPwd()).thenReturn(locationPassword);
+        SuplaRegisterDeviceA registerDeviceA = new SuplaRegisterDeviceA(
+                5,
+                locationPassword,
+                GUID,
+                NAME,
+                SOFT_VER,
+                (short) 0,
+                new pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelA[0]);
 
         RegisterDeviceTrait trait = RegisterDeviceTrait.fromProto(
                 (pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaRegisterDevice) registerDeviceA);
@@ -69,14 +55,15 @@ class RegisterDeviceTraitTest {
     @Test
     void shouldMapRegisterDeviceDToEmailTrait() {
         byte[] authKey = new byte[] {0x01, 0x02};
-        when(registerDeviceD.guid()).thenReturn(GUID);
-        when(registerDeviceD.name()).thenReturn(NAME);
-        when(registerDeviceD.softVer()).thenReturn(SOFT_VER);
-        when(registerDeviceD.channels())
-                .thenReturn(new pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelB[0]);
-        when(registerDeviceD.email()).thenReturn("user@example.com".getBytes());
-        when(registerDeviceD.authKey()).thenReturn(authKey);
-        when(registerDeviceD.serverName()).thenReturn("server.supla.org".getBytes());
+        SuplaRegisterDeviceD registerDeviceD = new SuplaRegisterDeviceD(
+                "user@example.com".getBytes(),
+                authKey,
+                GUID,
+                NAME,
+                SOFT_VER,
+                "server.supla.org".getBytes(),
+                (short) 0,
+                new pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelB[0]);
 
         RegisterDeviceTrait trait = RegisterDeviceTrait.fromProto(
                 (pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaRegisterDevice) registerDeviceD);
@@ -97,16 +84,18 @@ class RegisterDeviceTraitTest {
     @Test
     void shouldMapRegisterDeviceEWithManufacturerAndProduct() {
         byte[] authKey = new byte[] {0x05};
-        when(registerDeviceE.guid()).thenReturn(GUID);
-        when(registerDeviceE.name()).thenReturn(NAME);
-        when(registerDeviceE.softVer()).thenReturn(SOFT_VER);
-        when(registerDeviceE.channels())
-                .thenReturn(new pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelC[0]);
-        when(registerDeviceE.manufacturerId()).thenReturn((short) 10);
-        when(registerDeviceE.productId()).thenReturn((short) 20);
-        when(registerDeviceE.email()).thenReturn("another@example.com".getBytes());
-        when(registerDeviceE.authKey()).thenReturn(authKey);
-        when(registerDeviceE.serverName()).thenReturn("prod.server".getBytes());
+        SuplaRegisterDeviceE registerDeviceE = new SuplaRegisterDeviceE(
+                "another@example.com".getBytes(),
+                authKey,
+                GUID,
+                NAME,
+                SOFT_VER,
+                "prod.server".getBytes(),
+                0,
+                (short) 10,
+                (short) 20,
+                (short) 0,
+                new pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelC[0]);
 
         RegisterDeviceTrait trait = RegisterDeviceTrait.fromProto(
                 (pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaRegisterDevice) registerDeviceE);

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/traits/RegisterDeviceTraitTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/traits/RegisterDeviceTraitTest.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static pl.grzeslowski.jsupla.protocol.api.ProtocolHelpers.parseHexString;
 import static pl.grzeslowski.jsupla.protocol.api.ProtocolHelpers.parseString;
 
+import java.util.Arrays;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelValueA;
 import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaRegisterDeviceA;
 import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaRegisterDeviceD;
 import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaRegisterDeviceE;
@@ -16,7 +18,8 @@ class RegisterDeviceTraitTest {
     private static final byte[] NAME = "Test Device".getBytes();
     private static final byte[] SOFT_VER = "1.0".getBytes();
 
-    private final ToServerProto toServerProto = new ToServerProto() {};
+    private final ToServerProto toServerProto =
+            new SuplaDeviceChannelValueA((short) 1, new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
 
     @Test
     void shouldReturnEmptyOptionalWhenNotRegisterDevice() {
@@ -27,7 +30,8 @@ class RegisterDeviceTraitTest {
 
     @Test
     void shouldMapRegisterDeviceAToLocationTrait() {
-        byte[] locationPassword = new byte[] {0x0A};
+        byte[] locationPassword = new byte[33];
+        locationPassword[0] = 0x0A;
         SuplaRegisterDeviceA registerDeviceA = new SuplaRegisterDeviceA(
                 5,
                 locationPassword,
@@ -56,12 +60,12 @@ class RegisterDeviceTraitTest {
     void shouldMapRegisterDeviceDToEmailTrait() {
         byte[] authKey = new byte[] {0x01, 0x02};
         SuplaRegisterDeviceD registerDeviceD = new SuplaRegisterDeviceD(
-                "user@example.com".getBytes(),
+                Arrays.copyOf("user@example.com".getBytes(), 256),
                 authKey,
                 GUID,
                 NAME,
                 SOFT_VER,
-                "server.supla.org".getBytes(),
+                Arrays.copyOf("server.supla.org".getBytes(), 256),
                 (short) 0,
                 new pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaDeviceChannelB[0]);
 
@@ -85,12 +89,12 @@ class RegisterDeviceTraitTest {
     void shouldMapRegisterDeviceEWithManufacturerAndProduct() {
         byte[] authKey = new byte[] {0x05};
         SuplaRegisterDeviceE registerDeviceE = new SuplaRegisterDeviceE(
-                "another@example.com".getBytes(),
+                Arrays.copyOf("another@example.com".getBytes(), 256),
                 authKey,
                 GUID,
                 NAME,
                 SOFT_VER,
-                "prod.server".getBytes(),
+                Arrays.copyOf("prod.server".getBytes(), 256),
                 0,
                 (short) 10,
                 (short) 20,


### PR DESCRIPTION
## Summary
- replace Mockito struct mocks with real protocol record instances in trait and channel tests
- construct register device and channel value records directly to reflect actual protocol data
- update channel util assertions to use concrete SuplaChannelNewValueResult values

## Testing
- mvn -q -DskipTests compile


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f07a449608320b3c11bd4118c65da)