### PR TITLE
Handle status arguments without external Pair dependency

### DIFF
--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/cloud/handler/CloudBridgeHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/cloud/handler/CloudBridgeHandler.java
@@ -93,8 +93,7 @@ public class CloudBridgeHandler extends SuplaBridge implements IoDevicesCloudApi
             }
         } catch (Exception e) {
             throw new OfflineInitializationException(
-                    CONFIGURATION_ERROR,
-                    "Cannot create client to Supla Cloud! Probably oAuth token is incorrect! " + e.getMessage());
+                    CONFIGURATION_ERROR, "@text/supla.status.cloud.client-creation-error", e.getMessage());
         }
 
         // update channels
@@ -108,8 +107,9 @@ public class CloudBridgeHandler extends SuplaBridge implements IoDevicesCloudApi
         if (!supportedApiVersions.contains(apiVersion)) {
             throw new OfflineInitializationException(
                     CONFIGURATION_ERROR,
-                    "This API version `%s` is not supported! Supported api versions: [%s]."
-                            .formatted(apiVersion, String.join(", ", supportedApiVersions)));
+                    "@text/supla.status.cloud.api-version-not-supported",
+                    apiVersion,
+                    String.join(", ", supportedApiVersions));
         }
 
         var scheduledPool = ThreadPoolManager.getScheduledPool(THREAD_POOL_NAME);
@@ -132,7 +132,8 @@ public class CloudBridgeHandler extends SuplaBridge implements IoDevicesCloudApi
         try {
             return localServerCloudApi.getServerInfo();
         } catch (ApiException e) {
-            throw new OfflineInitializationException(COMMUNICATION_ERROR, "Cannot get server info! " + e.getMessage());
+            throw new OfflineInitializationException(
+                    COMMUNICATION_ERROR, "@text/supla.status.cloud.server-info-error", e.getMessage());
         }
     }
 

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/cloud/handler/CloudDevice.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/cloud/handler/CloudDevice.java
@@ -85,8 +85,7 @@ public final class CloudDevice extends SuplaDevice {
         @Nullable final Bridge bridge = getBridge();
         if (bridge == null) {
             logger.debug("No bridge for thing with UID {}", thing.getUID());
-            throw new OfflineInitializationException(
-                    BRIDGE_UNINITIALIZED, "There is no bridge for this thing. Remove it and add it again.");
+            throw new OfflineInitializationException(BRIDGE_UNINITIALIZED, "@text/supla.status.no-bridge");
         }
         final @Nullable BridgeHandler bridgeHandler = bridge.getHandler();
         if (!(bridgeHandler instanceof CloudBridgeHandler handler)) {
@@ -96,7 +95,7 @@ public final class CloudDevice extends SuplaDevice {
                     bridgeHandler != null ? bridgeHandler.getClass().getSimpleName() : "<null>",
                     thing.getUID());
             throw new OfflineInitializationException(
-                    BRIDGE_UNINITIALIZED, "There is wrong type of bridge for cloud device!");
+                    BRIDGE_UNINITIALIZED, "@text/supla.status.cloud.wrong-bridge-type");
         }
         initApi(handler);
 
@@ -125,7 +124,9 @@ public final class CloudDevice extends SuplaDevice {
         } catch (NumberFormatException e) {
             throw new OfflineInitializationException(
                     CONFIGURATION_ERROR,
-                    "Cannot parse cloud ID `%s` to integer! %s".formatted(cloudIdString, e.getLocalizedMessage()));
+                    "@text/supla.status.cloud-id.parse-error",
+                    cloudIdString,
+                    e.getLocalizedMessage());
         }
     }
 
@@ -138,7 +139,7 @@ public final class CloudDevice extends SuplaDevice {
         try {
             var device = findDevice(singletonList("connected"));
             if (device.isConnected() == null || !device.isConnected()) {
-                throw new OfflineInitializationException(NONE, "This device is is not connected to Supla Cloud.");
+                throw new OfflineInitializationException(NONE, "@text/supla.status.cloud.device-not-connected");
             }
         } catch (Exception e) {
             if (e instanceof InitializationException iex) {
@@ -146,7 +147,7 @@ public final class CloudDevice extends SuplaDevice {
             }
             logger.debug("Error when loading IO device from Supla Cloud!", e);
             throw new OfflineInitializationException(
-                    COMMUNICATION_ERROR, "Error when loading IO device from Supla Cloud! " + e.getLocalizedMessage());
+                    COMMUNICATION_ERROR, "@text/supla.status.cloud.io-device-error", e.getLocalizedMessage());
         }
     }
 
@@ -157,7 +158,7 @@ public final class CloudDevice extends SuplaDevice {
     private void checkIfIsEnabled() throws Exception {
         final Device device = findDevice(emptyList());
         if (device.isEnabled() == null || !device.isEnabled()) {
-            throw new OfflineInitializationException(NONE, "This device is turned off in Supla Cloud.");
+            throw new OfflineInitializationException(NONE, "@text/supla.status.cloud.device-turned-off");
         }
     }
 
@@ -174,7 +175,7 @@ public final class CloudDevice extends SuplaDevice {
             updateChannels(channels);
         } catch (Exception e) {
             throw new OfflineInitializationException(
-                    COMMUNICATION_ERROR, "Error when loading IO device from Supla Cloud! " + e.getLocalizedMessage());
+                    COMMUNICATION_ERROR, "@text/supla.status.cloud.io-device-error", e.getLocalizedMessage());
         }
     }
 
@@ -426,13 +427,11 @@ public final class CloudDevice extends SuplaDevice {
             thing.getChannels().stream().map(Channel::getUID).forEach(channelUID -> handleCommand(channelUID, REFRESH));
         } catch (Exception e) {
             if (e instanceof InitializationException iex) {
-                updateStatus(iex.getStatus(), iex.getStatusDetail(), iex.getMessage());
+                updateStatus(iex.getStatus(), iex.getStatusDetail(), iex.getMessage(), iex.getDescriptionArguments());
             } else {
                 logger.error("Cannot check if device `{}` is online/enabled", thing.getUID(), e);
                 updateStatus(
-                        OFFLINE,
-                        COMMUNICATION_ERROR,
-                        "Cannot check if device %s is online/enabled".formatted(thing.getUID()));
+                        OFFLINE, COMMUNICATION_ERROR, "@text/supla.status.cloud.device-check-error", thing.getUID());
             }
         }
     }

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/handler/InitializationException.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/handler/InitializationException.java
@@ -14,17 +14,25 @@ public class InitializationException extends Exception {
 
     private final ThingStatus status;
     private final ThingStatusDetail statusDetail;
+    private final Object[] descriptionArguments;
 
-    public InitializationException(ThingStatus status, ThingStatusDetail statusDetail, String description) {
+    public InitializationException(
+            ThingStatus status, ThingStatusDetail statusDetail, String description, Object... descriptionArguments) {
         super(description);
         this.status = status;
         this.statusDetail = statusDetail;
+        this.descriptionArguments = descriptionArguments;
     }
 
     public InitializationException(
-            ThingStatus status, ThingStatusDetail statusDetail, String description, Exception exception) {
+            ThingStatus status,
+            ThingStatusDetail statusDetail,
+            String description,
+            Exception exception,
+            Object... descriptionArguments) {
         super(description, exception);
         this.status = status;
         this.statusDetail = statusDetail;
+        this.descriptionArguments = descriptionArguments;
     }
 }

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/handler/OfflineInitializationException.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/handler/OfflineInitializationException.java
@@ -9,8 +9,9 @@ public class OfflineInitializationException extends InitializationException {
     @Serial
     private static final long serialVersionUID = 1L;
 
-    public OfflineInitializationException(ThingStatusDetail statusDetail, String description) {
-        super(OFFLINE, statusDetail, description);
+    public OfflineInitializationException(
+            ThingStatusDetail statusDetail, String description, Object... descriptionArguments) {
+        super(OFFLINE, statusDetail, description, descriptionArguments);
     }
 
     public OfflineInitializationException(ThingStatusDetail statusDetail, String description, Exception exception) {

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/handler/SuplaBridge.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/handler/SuplaBridge.java
@@ -4,8 +4,11 @@ import static org.openhab.core.thing.ThingStatus.OFFLINE;
 import static org.openhab.core.thing.ThingStatusDetail.CONFIGURATION_ERROR;
 import static pl.grzeslowski.openhab.supla.internal.GuidLogger.attachGuid;
 
+import java.text.MessageFormat;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.thing.Bridge;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.binding.BaseBridgeHandler;
 import org.slf4j.Logger;
 
@@ -20,13 +23,25 @@ public abstract class SuplaBridge extends BaseBridgeHandler {
             try {
                 internalInitialize();
             } catch (InitializationException e) {
-                updateStatus(e.getStatus(), e.getStatusDetail(), e.getMessage());
+                updateStatus(e.getStatus(), e.getStatusDetail(), e.getMessage(), e.getDescriptionArguments());
             } catch (Exception e) {
                 getLogger().error("Error occurred while initializing!", e);
                 updateStatus(
-                        OFFLINE, CONFIGURATION_ERROR, "Error occurred while initializing! " + e.getLocalizedMessage());
+                        OFFLINE,
+                        CONFIGURATION_ERROR,
+                        "@text/supla.status.initialization.generic-error",
+                        e.getLocalizedMessage());
             }
         });
+    }
+
+    protected void updateStatus(
+            ThingStatus thingStatus, ThingStatusDetail thingStatusDetail, String message, Object... messageArguments) {
+        super.updateStatus(thingStatus, thingStatusDetail, formatStatusDescription(message, messageArguments));
+    }
+
+    private String formatStatusDescription(String message, Object[] messageArguments) {
+        return messageArguments.length == 0 ? message : MessageFormat.format(message, messageArguments);
     }
 
     @Nullable

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/handler/SuplaDevice.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/handler/SuplaDevice.java
@@ -4,11 +4,14 @@ import static org.openhab.core.thing.ThingStatus.OFFLINE;
 import static org.openhab.core.thing.ThingStatusDetail.CONFIGURATION_ERROR;
 import static pl.grzeslowski.openhab.supla.internal.GuidLogger.attachGuid;
 
+import java.text.MessageFormat;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.library.types.*;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
+import org.openhab.core.thing.ThingStatus;
+import org.openhab.core.thing.ThingStatusDetail;
 import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.RefreshType;
@@ -28,13 +31,14 @@ public abstract class SuplaDevice extends BaseThingHandler implements HandleComm
             try {
                 internalInitialize();
             } catch (InitializationException e) {
-                updateStatus(e.getStatus(), e.getStatusDetail(), e.getMessage());
+                updateStatus(e.getStatus(), e.getStatusDetail(), e.getMessage(), e.getDescriptionArguments());
             } catch (Exception e) {
                 getLogger().error("Error occurred while initializing Supla device!", e);
                 updateStatus(
                         OFFLINE,
                         CONFIGURATION_ERROR,
-                        "Error occurred while initializing Supla device! " + e.getLocalizedMessage());
+                        "@text/supla.status.device.initialization-error",
+                        e.getLocalizedMessage());
             }
         });
     }
@@ -77,6 +81,15 @@ public abstract class SuplaDevice extends BaseThingHandler implements HandleComm
                                 ex);
             }
         });
+    }
+
+    protected void updateStatus(
+            ThingStatus thingStatus, ThingStatusDetail thingStatusDetail, String message, Object... messageArguments) {
+        super.updateStatus(thingStatus, thingStatusDetail, formatStatusDescription(message, messageArguments));
+    }
+
+    private String formatStatusDescription(String message, Object[] messageArguments) {
+        return messageArguments.length == 0 ? message : MessageFormat.format(message, messageArguments);
     }
 
     protected abstract Logger getLogger();

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/ChannelUtil.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/ChannelUtil.java
@@ -17,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.javatuples.Pair;
 import org.openhab.core.thing.Channel;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
@@ -31,6 +30,7 @@ import pl.grzeslowski.jsupla.protocol.api.structs.dsc.ChannelState;
 import pl.grzeslowski.openhab.supla.internal.server.handler.trait.ServerDevice;
 import pl.grzeslowski.openhab.supla.internal.server.traits.DeviceChannel;
 import pl.grzeslowski.openhab.supla.internal.server.traits.DeviceChannelValue;
+import pl.grzeslowski.openhab.supla.internal.util.Pair;
 
 @NonNullByDefault
 @RequiredArgsConstructor

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/device_config/DeviceConfigUtil.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/device_config/DeviceConfigUtil.java
@@ -15,8 +15,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.javatuples.Pair;
 import pl.grzeslowski.jsupla.protocol.api.decoders.*;
+import pl.grzeslowski.openhab.supla.internal.util.Pair;
 
 @UtilityClass
 @NonNullByDefault

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/GatewayDeviceHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/GatewayDeviceHandler.java
@@ -20,7 +20,6 @@ import java.util.stream.Collectors;
 import lombok.Getter;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.javatuples.Pair;
 import org.openhab.core.common.ThreadPoolManager;
 import org.openhab.core.library.types.*;
 import org.openhab.core.thing.ChannelUID;
@@ -46,6 +45,7 @@ import pl.grzeslowski.openhab.supla.internal.server.oh_config.TimeoutConfigurati
 import pl.grzeslowski.openhab.supla.internal.server.traits.DeviceChannel;
 import pl.grzeslowski.openhab.supla.internal.server.traits.DeviceChannelValue;
 import pl.grzeslowski.openhab.supla.internal.server.traits.RegisterDeviceTrait;
+import pl.grzeslowski.openhab.supla.internal.util.Pair;
 
 @NonNullByDefault
 public class GatewayDeviceHandler extends ServerSuplaDeviceHandler implements ServerBridge, ServerDevice {
@@ -95,7 +95,7 @@ public class GatewayDeviceHandler extends ServerSuplaDeviceHandler implements Se
     protected boolean afterRegister(RegisterDeviceTrait registerEntity) {
         var flags = registerEntity.flags();
         if (!flags.calcfgSubdevicePairing()) {
-            updateStatus(OFFLINE, CONFIGURATION_ERROR, "This is not a gateway device!");
+            updateStatus(OFFLINE, CONFIGURATION_ERROR, "@text/supla.status.gateway.not-gateway-device");
             return false;
         }
 
@@ -377,8 +377,9 @@ public class GatewayDeviceHandler extends ServerSuplaDeviceHandler implements Se
     }
 
     @Override
-    public void updateStatus(ThingStatus thingStatus, ThingStatusDetail thingStatusDetail, String message) {
-        super.updateStatus(thingStatus, thingStatusDetail, message);
+    public void updateStatus(
+            ThingStatus thingStatus, ThingStatusDetail thingStatusDetail, String message, Object... messageArguments) {
+        super.updateStatus(thingStatus, thingStatusDetail, message, messageArguments);
     }
 
     @Override

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerBridgeHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerBridgeHandler.java
@@ -85,17 +85,17 @@ public class ServerBridgeHandler extends SuplaBridge implements ServerBridge {
         var config = this.getConfigAs(ServerBridgeHandlerConfiguration.class);
         if (!config.isServerAuth() && !config.isEmailAuth()) {
             throw new OfflineInitializationException(
-                    CONFIGURATION_ERROR, "You need to pass either server auth or email auth!");
+                    CONFIGURATION_ERROR, "@text/supla.status.server.auth-config-missing");
         }
         if (config.getPort().intValue() <= 0) {
-            throw new OfflineInitializationException(CONFIGURATION_ERROR, "You need to pass port!");
+            throw new OfflineInitializationException(CONFIGURATION_ERROR, "@text/supla.status.server.port-missing");
         }
         authData = ServerBridge.buildAuthData(config);
         port = config.getPort().intValue();
         var protocols =
                 stream(config.getProtocols().split(",")).map(String::trim).collect(toSet());
         if (protocols.isEmpty()) {
-            throw new OfflineInitializationException(CONFIGURATION_ERROR, "You need to pass at least one protocol!");
+            throw new OfflineInitializationException(CONFIGURATION_ERROR, "@text/supla.status.server.protocol-missing");
         }
 
         logger = LoggerFactory.getLogger(ServerBridgeHandler.class.getName() + "." + port);
@@ -116,8 +116,10 @@ public class ServerBridgeHandler extends SuplaBridge implements ServerBridge {
             } catch (NoSuchAlgorithmException ex) {
                 throw new OfflineInitializationException(
                         HANDLER_INITIALIZING_ERROR,
-                        "Missing %s cryptographic algorithm! %s. See: %s"
-                                .formatted(algo, ex.getLocalizedMessage(), SSL_PROBLEM));
+                        "@text/supla.status.server.crypto-algorithm-missing",
+                        algo,
+                        ex.getLocalizedMessage(),
+                        SSL_PROBLEM);
             }
         } else {
             logger.info("Disabling SSL is not supported");
@@ -139,8 +141,9 @@ public class ServerBridgeHandler extends SuplaBridge implements ServerBridge {
                     var algorithms = String.join(", ", disabledAlgorithms);
                     throw new OfflineInitializationException(
                             CONFIGURATION_ERROR,
-                            "Those protocols are disabled in java.security: %s. See: %s"
-                                    .formatted(algorithms, Documentation.DISABLED_ALGORITHMS_PROBLEM));
+                            "@text/supla.status.server.protocols-disabled",
+                            algorithms,
+                            Documentation.DISABLED_ALGORITHMS_PROBLEM);
                 }
             } else {
                 logger.debug("jdk.tls.disabledAlgorithms is null, should not be a problem, carry on...");
@@ -156,8 +159,9 @@ public class ServerBridgeHandler extends SuplaBridge implements ServerBridge {
         } catch (CertificateException | SSLException ex) {
             throw new OfflineInitializationException(
                     HANDLER_INITIALIZING_ERROR,
-                    "Problem with generating certificates! %s. See: %s"
-                            .formatted(ex.getLocalizedMessage(), SSL_PROBLEM));
+                    "@text/supla.status.server.certificate-problem",
+                    ex.getLocalizedMessage(),
+                    SSL_PROBLEM);
         }
 
         logger.debug("jSuplaServer running on port {}", port);

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/SingleDevice.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/SingleDevice.java
@@ -63,8 +63,9 @@ public class SingleDevice extends ServerSuplaDeviceHandler implements ServerDevi
             updateStatus(
                     OFFLINE,
                     CONFIGURATION_ERROR,
-                    "Device should be created as %s. See %s for more information."
-                            .formatted(SUPLA_GATEWAY_DEVICE_TYPE.getId(), THING_BRIDGE));
+                    "@text/supla.status.server.device-should-be-created-as-gateway",
+                    SUPLA_GATEWAY_DEVICE_TYPE.getId(),
+                    THING_BRIDGE);
             return false;
         }
 
@@ -126,8 +127,9 @@ public class SingleDevice extends ServerSuplaDeviceHandler implements ServerDevi
     }
 
     @Override
-    public void updateStatus(ThingStatus thingStatus, ThingStatusDetail thingStatusDetail, String message) {
-        super.updateStatus(thingStatus, thingStatusDetail, message);
+    public void updateStatus(
+            ThingStatus thingStatus, ThingStatusDetail thingStatusDetail, String message, Object... messageArguments) {
+        super.updateStatus(thingStatus, thingStatusDetail, message, messageArguments);
     }
 
     @Override

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/SubDeviceHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/SubDeviceHandler.java
@@ -83,10 +83,7 @@ public class SubDeviceHandler extends SuplaDevice implements ServerDevice {
         {
             var bridge = getBridge();
             if (bridge == null) {
-                updateStatus(
-                        OFFLINE,
-                        BRIDGE_UNINITIALIZED,
-                        "There is no bridge for this thing. Remove it and add it again.");
+                updateStatus(OFFLINE, BRIDGE_UNINITIALIZED, "@text/supla.status.no-bridge");
                 return;
             }
             var rawBridgeHandler = bridge.getHandler();
@@ -100,8 +97,9 @@ public class SubDeviceHandler extends SuplaDevice implements ServerDevice {
                 updateStatus(
                         OFFLINE,
                         CONFIGURATION_ERROR,
-                        "Bridge has wrong type! Should be " + GatewayDeviceHandler.class.getSimpleName() + ", but was "
-                                + simpleName);
+                        "@text/supla.status.subdevice.wrong-bridge-type",
+                        GatewayDeviceHandler.class.getSimpleName(),
+                        simpleName);
                 return;
             }
             this.bridgeHandler = localBridgeHandler;
@@ -111,13 +109,13 @@ public class SubDeviceHandler extends SuplaDevice implements ServerDevice {
             var config = getConfigAs(ServerSubDeviceHandlerConfiguration.class);
             subDeviceId = config.getId();
             if (subDeviceId < 1) {
-                updateStatus(OFFLINE, CONFIGURATION_ERROR, "There is no ID for this thing.");
+                updateStatus(OFFLINE, CONFIGURATION_ERROR, "@text/supla.status.subdevice.id-missing");
                 return;
             }
         } // config
         guid = requireNonNull(bridgeHandler).getGuid() + "." + subDeviceId;
         logger = LoggerFactory.getLogger("%s.%s".formatted(this.getClass().getName(), guid));
-        updateStatus(ThingStatus.UNKNOWN, CONFIGURATION_PENDING, "Waiting for gateway");
+        updateStatus(ThingStatus.UNKNOWN, CONFIGURATION_PENDING, "@text/supla.status.subdevice.waiting-for-gateway");
     }
 
     @Override
@@ -143,7 +141,7 @@ public class SubDeviceHandler extends SuplaDevice implements ServerDevice {
         this.channels = channels;
         channelUtil.buildChannels(channels);
         if (channels.isEmpty()) {
-            updateStatus(OFFLINE, CONFIGURATION_ERROR, "No channels.");
+            updateStatus(OFFLINE, CONFIGURATION_ERROR, "@text/supla.status.subdevice.no-channels");
         } else {
             updateStatus(ONLINE);
         }
@@ -188,8 +186,9 @@ public class SubDeviceHandler extends SuplaDevice implements ServerDevice {
     }
 
     @Override
-    public void updateStatus(ThingStatus thingStatus, ThingStatusDetail thingStatusDetail, String message) {
-        super.updateStatus(thingStatus, thingStatusDetail, message);
+    public void updateStatus(
+            ThingStatus thingStatus, ThingStatusDetail thingStatusDetail, String message, Object... messageArguments) {
+        super.updateStatus(thingStatus, thingStatusDetail, message, messageArguments);
     }
 
     @Override

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/HandlerCommandTrait.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/HandlerCommandTrait.java
@@ -15,7 +15,6 @@ import jakarta.annotation.Nullable;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.javatuples.Pair;
 import org.openhab.core.library.types.*;
 import org.openhab.core.thing.ChannelGroupUID;
 import org.openhab.core.thing.ChannelUID;
@@ -24,6 +23,7 @@ import org.openhab.core.types.State;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.encoders.ChannelTypeEncoderImpl;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.*;
 import pl.grzeslowski.jsupla.protocol.api.structs.sd.SuplaChannelNewValue;
+import pl.grzeslowski.openhab.supla.internal.util.Pair;
 
 @NonNullByDefault
 @RequiredArgsConstructor
@@ -269,7 +269,13 @@ public class HandlerCommandTrait implements HandleCommand {
             return future;
         } catch (Exception ex) {
             var msg = "Couldn't Change value of channel for %s command %s. ".formatted(channelUID, command);
-            serverDevice.updateStatus(OFFLINE, COMMUNICATION_ERROR, msg + ex.getLocalizedMessage());
+            serverDevice.updateStatus(
+                    OFFLINE,
+                    COMMUNICATION_ERROR,
+                    "@text/supla.status.server.channel-change-error",
+                    channelUID,
+                    command,
+                    ex.getLocalizedMessage());
             throw ex;
         }
     }

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/ServerDevice.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/ServerDevice.java
@@ -36,7 +36,8 @@ public interface ServerDevice extends HandleCommand, StateCache {
 
     void updateState(ChannelUID uid, State state);
 
-    void updateStatus(ThingStatus thingStatus, ThingStatusDetail thingStatusDetail, String message);
+    void updateStatus(
+            ThingStatus thingStatus, ThingStatusDetail thingStatusDetail, String message, Object... messageArguments);
 
     void updateStatus(ThingStatus thingStatus);
 

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/util/Pair.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/util/Pair.java
@@ -1,0 +1,16 @@
+package pl.grzeslowski.openhab.supla.internal.util;
+
+/** Simple generic pair to replace external tuple dependency. */
+public record Pair<A, B>(A value0, B value1) {
+    public static <A, B> Pair<A, B> with(A value0, B value1) {
+        return new Pair<>(value0, value1);
+    }
+
+    public A getValue0() {
+        return value0;
+    }
+
+    public B getValue1() {
+        return value1;
+    }
+}

--- a/src/main/resources/OH-INF/i18n/supla.properties
+++ b/src/main/resources/OH-INF/i18n/supla.properties
@@ -1,3 +1,41 @@
 # FIXME: please add all English translations to this file so the texts can be translated using Crowdin
 # FIXME: to generate the content of this file run: mvn i18n:generate-default-translations
 # FIXME: see also: https://www.openhab.org/docs/developer/utils/i18n.html
+supla.status.no-bridge = Keine Bridge für dieses Element. Entfernen Sie es und fügen Sie es erneut hinzu.
+supla.status.cloud.wrong-bridge-type = Falscher Brückentyp für Cloud-Gerät!
+supla.status.cloud-id.parse-error = Die Cloud-ID ''{0}'' kann nicht in eine ganze Zahl umgewandelt werden! {1}
+supla.status.cloud.device-not-connected = Dieses Gerät ist nicht mit Supla Cloud verbunden.
+supla.status.cloud.io-device-error = Fehler beim Laden des IO-Geräts aus Supla Cloud! {0}
+supla.status.cloud.device-turned-off = Dieses Gerät ist in Supla Cloud ausgeschaltet.
+supla.status.cloud.client-creation-error = Kann keinen Client für Supla Cloud erstellen! OAuth-Token ist wahrscheinlich ungültig! {0}
+supla.status.cloud.api-version-not-supported = Diese API-Version ''{0}'' wird nicht unterstützt! Unterstützte API-Versionen: [{1}].
+supla.status.cloud.server-info-error = Serverinformationen können nicht abgerufen werden! {0}
+supla.status.cloud.device-check-error = Es kann nicht überprüft werden, ob Gerät {0} online/eingeschaltet ist
+supla.status.server.auth-config-missing = Serverauthentifizierung oder E-Mail-Authentifizierung muss angegeben werden.
+supla.status.server.port-missing = Port muss angegeben werden!
+supla.status.server.protocol-missing = Mindestens ein Protokoll muss angegeben werden!
+supla.status.server.crypto-algorithm-missing = Kryptografie-Algorithmus {0} fehlt! {1}. Siehe: {2}
+supla.status.server.protocols-disabled = Protokolle {0} sind in der Datei java.security deaktiviert. Siehe: {1}
+supla.status.server.certificate-problem = Problem beim Erzeugen der Zertifikate! {0}. Siehe: {1}
+supla.status.server.wrong-bridge-type = Bridge hat falschen Typ! Sollte {0} sein, war aber {1}
+supla.status.server.missing-guid = Für dieses Element fehlt die GUID.
+supla.status.server.waiting-for-device-connection = Warten auf die Verbindung des Supla-Geräts mit dem Server
+supla.status.server.message-pipeline-error = Fehler in der Nachrichten-Pipeline. {0}
+supla.status.server.channel-disconnected = Kanal getrennt
+supla.status.server.device-authorizing = Gerät wird autorisiert...
+supla.status.server.waiting-registration-confirmation = Warten auf Registrierungsbestätigung vom Gerät...
+supla.status.server.authorization-failed.location = Geräteautorisierung fehlgeschlagen. Gerät versuchte sich mit locationId={0} und locationPassword={1} anzumelden
+supla.status.server.authorization-failed.email = Geräteautorisierung fehlgeschlagen. Gerät versuchte sich mit email={0} und authKey={1} anzumelden
+supla.status.server.missing-ping = Gerät hat in den letzten {0} Sekunden keine Ping-Nachricht gesendet. Letzte Nachricht stammt von {1}
+supla.status.server.socket-timeout = Socket-Timeout
+supla.status.server.socket-exception = Socket-Ausnahme. {0}
+supla.status.server.socket-generic-exception = Socket-Ausnahme {0}: {1}
+supla.status.server.channel-change-error = Kanalwert für {0} konnte nicht geändert werden, Befehl {1}. {2}
+supla.status.initialization.generic-error = Bei der Initialisierung ist ein Fehler aufgetreten! {0}
+supla.status.device.initialization-error = Bei der Initialisierung des Supla-Geräts ist ein Fehler aufgetreten! {0}
+supla.status.gateway.not-gateway-device = Dies ist kein Gateway-Gerät!
+supla.status.subdevice.wrong-bridge-type = Bridge hat falschen Typ! Sollte {0} sein, war aber {1}
+supla.status.subdevice.id-missing = Für dieses Element fehlt die ID.
+supla.status.subdevice.waiting-for-gateway = Warten auf Gateway
+supla.status.subdevice.no-channels = Keine Kanäle.
+supla.status.server.device-should-be-created-as-gateway = Gerät sollte als {0} erstellt werden. Siehe {1}, um weitere Informationen zu erhalten.


### PR DESCRIPTION
## Summary
- add an internal generic Pair record to replace the removed org.javatuples dependency
- extend bridge and device status updates to accept optional description arguments with local formatting helpers
- update server handlers to use the new status update helpers while continuing to support existing channel/state utilities

## Testing
- `mvn spotless:apply test`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922fa7dbd308320a117abb5dd2a9bc3)