### PR TITLE
Add script to update Java TLS security settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,15 +223,8 @@ the following paths:
 ##### Docker 🐳
 
 1. Log in into container: `docker exec -it <docker-container-id> /bin/bash`
-2. Go to folder with `java.security`: `cd /usr/lib/jvm/java-1.21.0-openjdk-amd64/conf/security`
-3. Do a backup: `cp java.security java.security.bak`
-4. Check current settings: `cat java.security | grep jdk.tls.disabledAlgorithms`
-5. Replace
-it:
-`sed -i -E '/^jdk\.tls\.disabledAlgorithms=/ s/(,\s*)?(SSLv3|TLSv1\.1?|TLSv1)(,\s*)?//g' java.security`
-6. Check changed settings: `cat java.security | grep jdk.tls.disabledAlgorithms`
-7. Compare changes: `diff java.security java.security.bak`
-8. Exit and restart docker container
+2. Invoke: `curl -fsSL https://raw.githubusercontent.com/magx2/openhab-supla/refs/heads/master/bin/update-java-tls.sh | bash`
+3. Exit and restart docker container
 
 #### Restarting OpenHAB
 

--- a/bin/update-java-tls.sh
+++ b/bin/update-java-tls.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Colored logging functions
 # -----------------------------
 COLOR_RESET="\e[0m"
-COLOR_BLUE="\e[34m"
+COLOR_CYAN="\e[36m"
 COLOR_GREEN="\e[32m"
 COLOR_YELLOW="\e[33m"
 COLOR_RED="\e[31m"

--- a/bin/update-java-tls.sh
+++ b/bin/update-java-tls.sh
@@ -5,12 +5,12 @@ set -euo pipefail
 # Colored logging functions
 # -----------------------------
 COLOR_RESET="\e[0m"
-COLOR_BLUE="\e[34m"
+COLOR_CYAN="\e[36m"
 COLOR_GREEN="\e[32m"
 COLOR_YELLOW="\e[33m"
 COLOR_RED="\e[31m"
 
-log_step()  { echo -e "${COLOR_BLUE}\n==> $1${COLOR_RESET}"; }
+log_step()  { echo -e "${COLOR_CYAN}[STEP]${COLOR_RESET} $1"; }
 log_info()  { echo -e "${COLOR_GREEN}[INFO]${COLOR_RESET} $1"; }
 log_warn()  { echo -e "${COLOR_YELLOW}[WARN]${COLOR_RESET} $1"; }
 log_error() { echo -e "${COLOR_RED}[ERROR]${COLOR_RESET} $1" >&2; }

--- a/bin/update-java-tls.sh
+++ b/bin/update-java-tls.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# -----------------------------
+# Colored logging functions
+# -----------------------------
+COLOR_RESET="\e[0m"
+COLOR_BLUE="\e[34m"
+COLOR_GREEN="\e[32m"
+COLOR_YELLOW="\e[33m"
+COLOR_RED="\e[31m"
+
+log_step()  { echo -e "${COLOR_BLUE}\n==> $1${COLOR_RESET}"; }
+log_info()  { echo -e "${COLOR_GREEN}[INFO]${COLOR_RESET} $1"; }
+log_warn()  { echo -e "${COLOR_YELLOW}[WARN]${COLOR_RESET} $1"; }
+log_error() { echo -e "${COLOR_RED}[ERROR]${COLOR_RESET} $1" >&2; }
+
+# -----------------------------
+# Configuration
+# -----------------------------
+SEC_DIR="/usr/lib/jvm/java-1.21.0-openjdk-amd64/conf/security"
+SEC_FILE="${SEC_DIR}/java.security"
+BACKUP_FILE="${SEC_FILE}.bak"
+
+log_step "Switching to Java security directory: ${SEC_DIR}"
+cd "${SEC_DIR}" || { log_error "Failed to cd into ${SEC_DIR}"; exit 1; }
+
+# -----------------------------
+# Backup
+# -----------------------------
+if [[ ! -f "${SEC_FILE}" ]]; then
+    log_error "Security file not found: ${SEC_FILE}"
+    exit 1
+fi
+
+log_step "Creating backup"
+cp -p "${SEC_FILE}" "${BACKUP_FILE}"
+log_info "Backup created: ${BACKUP_FILE}"
+
+# -----------------------------
+# Read current value
+# -----------------------------
+log_step "Current jdk.tls.disabledAlgorithms:"
+grep '^jdk.tls.disabledAlgorithms=' "${SEC_FILE}" || log_warn "Entry not found"
+
+# -----------------------------
+# Apply update
+# -----------------------------
+log_step "Updating jdk.tls.disabledAlgorithms (removing SSLv3 / TLSv1 / TLSv1.1)"
+
+sed -i -E '/^jdk\.tls\.disabledAlgorithms=/ s/(,\s*)?(SSLv3|TLSv1\.1?|TLSv1)(,\s*)?//g' "${SEC_FILE}"
+
+log_info "Update applied successfully"
+
+# -----------------------------
+# Show updated line
+# -----------------------------
+log_step "Updated jdk.tls.disabledAlgorithms:"
+grep '^jdk.tls.disabledAlgorithms=' "${SEC_FILE}" || log_warn "Entry not found"
+
+# -----------------------------
+# Diff vs backup
+# -----------------------------
+log_step "Comparing changes with backup:"
+if diff -u "${BACKUP_FILE}" "${SEC_FILE}"; then
+    log_warn "No changes detected (files identical?)"
+else
+    log_info "Differences shown above"
+fi
+
+log_step "Done."

--- a/bin/update-java-tls.sh
+++ b/bin/update-java-tls.sh
@@ -26,8 +26,8 @@ log_step "Switching to Java security directory: ${SEC_DIR}"
 cd "${SEC_DIR}" || { log_error "Failed to cd into ${SEC_DIR}"; exit 1; }
 
 if [[ ! -f "${SEC_FILE}" ]]; then
-    log_error "Security file not found: ${SEC_FILE}"
-    exit 1
+	log_error "Security file not found: ${SEC_FILE}"
+	exit 1
 fi
 
 # -----------------------------
@@ -42,7 +42,7 @@ log_info "Backup created: ${BACKUP_FILE}"
 # -----------------------------
 log_step "Current jdk.tls.disabledAlgorithms line:"
 if ! grep '^jdk.tls.disabledAlgorithms=' "${SEC_FILE}"; then
-    log_warn "Entry jdk.tls.disabledAlgorithms not found"
+	log_warn "Entry jdk.tls.disabledAlgorithms not found"
 fi
 
 # -----------------------------
@@ -54,40 +54,40 @@ TMP_FILE="$(mktemp "${SEC_FILE}.XXXXXX")"
 
 awk -F= '
 BEGIN {
-    OFS="=";
+	OFS="=";
 }
 # Process only the jdk.tls.disabledAlgorithms line
 /^jdk\.tls\.disabledAlgorithms=/ {
-    key = $1;
-    value = $2;
+	key = $1;
+	value = $2;
 
-    # Split by comma into algorithms
-    n = split(value, arr, ",");
+	# Split by comma into algorithms
+	n = split(value, arr, ",");
 
-    out = "";
-    for (i = 1; i <= n; i++) {
-        alg = arr[i];
+	out = "";
+	for (i = 1; i <= n; i++) {
+		alg = arr[i];
 
-        # trim leading/trailing spaces
-        gsub(/^[[:space:]]+|[[:space:]]+$/, "", alg);
+		# trim leading/trailing spaces
+		gsub(/^[[:space:]]+|[[:space:]]+$/, "", alg);
 
-        # skip unwanted protocols
-        if (alg ~ /^(SSLv3|TLSv1\.1?|TLSv1)$/) {
-            continue;
-        }
+		# skip unwanted protocols
+		if (alg ~ /^(SSLv3|TLSv1\.1?|TLSv1)$/) {
+			continue;
+		}
 
-        # rebuild with ", " as separator
-        if (alg != "") {
-            if (out == "") {
-                out = alg;
-            } else {
-                out = out ", " alg;
-            }
-        }
-    }
+		# rebuild with ", " as separator
+		if (alg != "") {
+			if (out == "") {
+				out = alg;
+			} else {
+				out = out ", " alg;
+			}
+		}
+	}
 
-    print key, out;
-    next;
+	print key, out;
+	next;
 }
 # All other lines unchanged
 { print }
@@ -101,7 +101,7 @@ log_info "Update applied successfully"
 # -----------------------------
 log_step "Updated jdk.tls.disabledAlgorithms line:"
 if ! grep '^jdk.tls.disabledAlgorithms=' "${SEC_FILE}"; then
-    log_warn "Entry jdk.tls.disabledAlgorithms not found after update (unexpected)"
+	log_warn "Entry jdk.tls.disabledAlgorithms not found after update (unexpected)"
 fi
 
 # -----------------------------
@@ -109,9 +109,9 @@ fi
 # -----------------------------
 log_step "Comparing changes with backup:"
 if diff -u "${BACKUP_FILE}" "${SEC_FILE}"; then
-    log_warn "No changes detected (files identical?)"
+	log_warn "No changes detected (files identical?)"
 else
-    log_info "Differences shown above"
+	log_info "Differences shown above"
 fi
 
 log_step "Done."


### PR DESCRIPTION
This script updates the Java security configuration by modifying the jdk.tls.disabledAlgorithms setting to remove SSLv3, TLSv1, and TLSv1.1. It includes logging for each step, backup creation, and a diff comparison with the backup file.