### PR TITLE
Remove deprecated StateCache method

### DIFF
--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/cache/InMemoryStateCache.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/cache/InMemoryStateCache.java
@@ -4,6 +4,7 @@ import static java.util.Collections.synchronizedMap;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.thing.ChannelUID;
@@ -16,10 +17,10 @@ public class InMemoryStateCache implements StateCache {
     private final Logger logger;
 
     @Override
-    public @Nullable State findStateDeprecated(ChannelUID uid) {
+    public Optional<State> findState(ChannelUID uid) {
         var state = stateCache.get(uid);
         logger.debug("Current state for {} is {}", uid, state);
-        return state;
+        return Optional.ofNullable(state);
     }
 
     @Override

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/cache/StateCache.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/cache/StateCache.java
@@ -6,13 +6,7 @@ import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.types.State;
 
 public interface StateCache {
-    @Nullable
-    @Deprecated
-    State findStateDeprecated(ChannelUID uid);
-
-    default Optional<State> findState(ChannelUID uid) {
-        return Optional.ofNullable(findStateDeprecated(uid));
-    }
+    Optional<State> findState(ChannelUID uid);
 
     void saveState(ChannelUID uid, @Nullable State state);
 }

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/HandlerCommandTrait.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/HandlerCommandTrait.java
@@ -37,11 +37,7 @@ public class HandlerCommandTrait implements HandleCommand {
 
     @Override
     public void handleRefreshCommand(ChannelUID channelUID) {
-        var state = serverDevice.findStateDeprecated(channelUID);
-        if (state == null) {
-            return;
-        }
-        serverDevice.updateState(channelUID, state);
+        serverDevice.findState(channelUID).ifPresent(state -> serverDevice.updateState(channelUID, state));
     }
 
     @Override
@@ -184,7 +180,7 @@ public class HandlerCommandTrait implements HandleCommand {
                                         false, false));
                 };
 
-        var previousMode = serverDevice.findStateDeprecated(channelUID);
+        var previousMode = serverDevice.findState(channelUID).orElse(null);
         var future = sendCommandToSuplaServer(channelUID, value, command, previousMode);
     }
 
@@ -202,7 +198,7 @@ public class HandlerCommandTrait implements HandleCommand {
     private Double findTemperature(ChannelUID channelUID, String id) {
         return Optional.of(channelUID)
                 .map(uid -> siblingChannel(uid, id))
-                .map(serverDevice::findStateDeprecated)
+                .flatMap(serverDevice::findState)
                 .<QuantityType<?>>map(state -> (QuantityType<?>) state)
                 .filter(state -> state.getUnit().isCompatible(CELSIUS))
                 .map(state -> state.toUnit(CELSIUS))

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/cache/InMemoryStateCacheTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/cache/InMemoryStateCacheTest.java
@@ -41,9 +41,9 @@ class InMemoryStateCacheTest {
         };
 
         cache.saveState(channelUID, state);
-        var found = cache.findStateDeprecated(channelUID);
+        var found = cache.findState(channelUID);
 
-        assertThat(found).isEqualTo(state);
+        assertThat(found).hasValue(state);
         verify(logger).debug("Saving state {}={}", channelUID, state);
         verify(logger).debug("Current state for {} is {}", channelUID, state);
     }
@@ -53,9 +53,9 @@ class InMemoryStateCacheTest {
         ChannelUID channelUID = new ChannelUID("binding:thing:2:channel");
 
         cache.saveState(channelUID, null);
-        var found = cache.findStateDeprecated(channelUID);
+        var found = cache.findState(channelUID);
 
-        assertThat(found).isNull();
+        assertThat(found).isEmpty();
         verify(logger).debug("Saving state {}={}", channelUID, null);
         verify(logger).debug("Current state for {} is {}", channelUID, null);
     }

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/HandlerCommandTraitTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/HandlerCommandTraitTest.java
@@ -12,6 +12,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
 import java.util.HashMap;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,7 +72,7 @@ class HandlerCommandTraitTest {
                 return "state";
             }
         };
-        when(serverDevice.findStateDeprecated(channelUID)).thenReturn(state);
+        when(serverDevice.findState(channelUID)).thenReturn(Optional.of(state));
 
         handlerCommandTrait.handleRefreshCommand(channelUID);
 
@@ -81,7 +82,7 @@ class HandlerCommandTraitTest {
     @Test
     void shouldNotRefreshWhenStateMissing() {
         ChannelUID channelUID = new ChannelUID("binding:thing:sub:1");
-        when(serverDevice.findStateDeprecated(channelUID)).thenReturn(null);
+        when(serverDevice.findState(channelUID)).thenReturn(Optional.empty());
 
         handlerCommandTrait.handleRefreshCommand(channelUID);
 


### PR DESCRIPTION
## Summary
- replace the deprecated state lookup with StateCache.findState across the server code
- update the in-memory cache implementation to return Optional values with consistent logging
- adjust handler logic and tests to consume the new Optional-based API

## Testing
- mvn spotless:apply
- mvn test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695522b27aac8320ae84b27c297c1b71)