### PR TITLE
Ensure RandomExtension picks available ports

### DIFF
--- a/src/integration-test/java/pl/grzeslowski/openhab/supla/internal/extension/random/RandomExtension.java
+++ b/src/integration-test/java/pl/grzeslowski/openhab/supla/internal/extension/random/RandomExtension.java
@@ -6,7 +6,9 @@ import static java.util.stream.Stream.generate;
 import static pl.grzeslowski.jsupla.protocol.api.consts.ProtoConsts.*;
 import static pl.grzeslowski.openhab.supla.internal.server.ByteArrayToHex.bytesToHex;
 
+import java.io.IOException;
 import java.math.BigDecimal;
+import java.net.ServerSocket;
 import java.util.Random;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -124,6 +126,14 @@ public class RandomExtension implements ParameterResolver {
         return random.nextBoolean();
     }
 
+    private int openPort() {
+        try (var serverSocket = new ServerSocket(0)) {
+            return serverSocket.getLocalPort();
+        } catch (IOException exception) {
+            throw new ParameterResolutionException("Could not allocate open port", exception);
+        }
+    }
+
     @Override
     public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
             throws ParameterResolutionException {
@@ -155,7 +165,7 @@ public class RandomExtension implements ParameterResolver {
             return randomGuid();
         }
         if (parameterContext.isAnnotated(Port.class)) {
-            return random.nextInt(0xFFFF) + 1;
+            return openPort();
         }
         if (parameterContext.isAnnotated(LocationId.class)) {
             return randomLocationId();


### PR DESCRIPTION
## Summary
- allocate open ports for `@Port` parameters by binding a temporary `ServerSocket`
- reuse the helper when resolving port parameters in integration tests

## Testing
- mvn spotless:apply
- mvn test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695522404824832091829092884b45b0)