### PR TITLE
Disable Maven transfer progress in CI workflows

### DIFF
--- a/.github/workflows/maven-main.yml
+++ b/.github/workflows/maven-main.yml
@@ -19,7 +19,7 @@ jobs:
           cache: maven
       - name: Spotless
         run: |
-          mvn -B spotless:apply
+          mvn -B -ntp spotless:apply
           
           if [[ `git status --porcelain -uno` ]]; then
             echo "❌ Code was not formatted properly"
@@ -48,7 +48,7 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven
-        run: mvn -B spotless:check verify --file pom.xml
+        run: mvn -B -ntp spotless:check verify --file pom.xml
 
       # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
       - name: Maven Dependency Tree Dependency Submission

--- a/.github/workflows/maven-pr.yml
+++ b/.github/workflows/maven-pr.yml
@@ -15,5 +15,5 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven
-        run: mvn spotless:check verify
+        run: mvn -B -ntp spotless:check verify
 


### PR DESCRIPTION
## Summary
- add the Maven `-ntp` flag to CI workflows to suppress transfer progress logging on GitHub runners

## Testing
- mvn -B -ntp spotless:apply
- mvn -B -ntp test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695521c9fd14832088abad28ed233c60)