### PR TITLE
Add unit tests for TimeoutConfiguration

### DIFF
--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/oh_config/TimeoutConfigurationTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/oh_config/TimeoutConfigurationTest.java
@@ -1,0 +1,43 @@
+package pl.grzeslowski.openhab.supla.internal.server.oh_config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class TimeoutConfigurationTest {
+    @Test
+    void shouldKeepTimeoutValues() {
+        var timeout = new TimeoutConfiguration(Duration.ofSeconds(5), Duration.ofSeconds(3), Duration.ofSeconds(7));
+
+        assertThat(timeout.timeout()).isEqualTo(Duration.ofSeconds(5));
+        assertThat(timeout.min()).isEqualTo(Duration.ofSeconds(3));
+        assertThat(timeout.max()).isEqualTo(Duration.ofSeconds(7));
+    }
+
+    @Test
+    void shouldConvertIntSecondsToDuration() {
+        var timeout = new TimeoutConfiguration(6, 4, 9);
+
+        assertThat(timeout.timeout()).isEqualTo(Duration.ofSeconds(6));
+        assertThat(timeout.min()).isEqualTo(Duration.ofSeconds(4));
+        assertThat(timeout.max()).isEqualTo(Duration.ofSeconds(9));
+    }
+
+    @Test
+    void shouldRejectMinGreaterThanTimeout() {
+        assertThatThrownBy(() ->
+                        new TimeoutConfiguration(Duration.ofSeconds(5), Duration.ofSeconds(6), Duration.ofSeconds(7)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("min (PT6S) has to be smaller than timeout (PT5S)!");
+    }
+
+    @Test
+    void shouldRejectTimeoutGreaterThanMax() {
+        assertThatThrownBy(() ->
+                        new TimeoutConfiguration(Duration.ofSeconds(8), Duration.ofSeconds(6), Duration.ofSeconds(7)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("timeout (PT8S) has to be smaller than max (PT7S)!");
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure `TimeoutConfiguration` correctly stores `Duration` values and converts integer seconds to `Duration`.
- Verify the validation logic rejects invalid ordering where `min` > `timeout` or `timeout` > `max`.

### Description
- Add `src/test/java/pl/grzeslowski/openhab/supla/internal/server/oh_config/TimeoutConfigurationTest.java` with unit tests.
- Tests cover valid `Duration` construction, int-second constructor conversion, and the two validation failure cases that throw `IllegalArgumentException` with exact messages.

### Testing
- Ran `mvn test` and the test suite completed successfully with all tests passing (including the new `TimeoutConfigurationTest`).
- The new test class contains 4 tests which passed as part of the full test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69639dc70820832098e782e178c8dc98)