### PR TITLE
Add Spotless XML formatting for resource XML files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -465,6 +465,7 @@ bcutil-jdk15on-*.jar;lib:=true
                                 <exclude>src/main/java/**/*.java</exclude>
                                 <exclude>src/test/java/**/*.java</exclude>
                                 <exclude>src/integration-test/java/**/*.java</exclude>
+                                <exclude>src/*/resources/**/*.xml</exclude>
                                 <exclude>.github/workflows/*.yml</exclude>
                                 <exclude>*.http</exclude>
                                 <exclude>imgs/**</exclude>
@@ -475,6 +476,14 @@ bcutil-jdk15on-*.jar;lib:=true
                                 <tabs>true</tabs>
                                 <spacesPerTab>4</spacesPerTab>
                             </indent>
+                        </format>
+                        <format>
+                            <includes>
+                                <include>src/*/resources/**/*.xml</include>
+                            </includes>
+                            <eclipseWtp>
+                                <type>XML</type>
+                            </eclipseWtp>
                         </format>
                     </formats>
                     <java>

--- a/src/integration-test/resources/logback-test.xml
+++ b/src/integration-test/resources/logback-test.xml
@@ -1,13 +1,16 @@
 <configuration>
-	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+	<appender name="STDOUT"
+		class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
-			<pattern>%d{HH:mm:ss.SSS} [%thread] [guid=%X{GUID}] %-5level %logger{36} - %msg%n</pattern>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] [guid=%X{GUID}] %-5level
+				%logger{36} - %msg%n</pattern>
 		</encoder>
 	</appender>
 
-	<logger name="pl.grzeslowski.openhab.supla.internal" level="debug"/>
+	<logger name="pl.grzeslowski.openhab.supla.internal"
+		level="debug" />
 
 	<root level="warn">
-		<appender-ref ref="STDOUT"/>
+		<appender-ref ref="STDOUT" />
 	</root>
 </configuration>

--- a/src/main/resources/OH-INF/addon/addon.xml
+++ b/src/main/resources/OH-INF/addon/addon.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon:addon id="supla" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<addon:addon id="supla"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:addon="https://openhab.org/schemas/addon/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
 

--- a/src/main/resources/OH-INF/binding/binding.xml
+++ b/src/main/resources/OH-INF/binding/binding.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<binding:binding id="supla" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<binding:binding id="supla"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:binding="https://openhab.org/schemas/binding/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/binding/v1.0.0 https://openhab.org/schemas/binding-1.0.0.xsd">
 
 	<name>Supla Binding</name>
-	<description>This binding is able to create native server for Supla devices.
+	<description>This binding is able to create native server for Supla
+		devices.
 		For more information visit &lt;a
 		href="https://github.com/magx2/jSupla"&gt;https://github.com/magx2/jSupla&lt;/a&gt;.
 		To get familiar with Supla system
-		visit &lt;a href="https://www.supla.org"&gt;https://www.supla.org&lt;/a&gt; </description>
+		visit &lt;a
+		href="https://www.supla.org"&gt;https://www.supla.org&lt;/a&gt; </description>
 	<author>Martin Grzeslowski</author>
 
 </binding:binding>

--- a/src/main/resources/OH-INF/thing/hvac-thing-types.xml
+++ b/src/main/resources/OH-INF/thing/hvac-thing-types.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="supla"
-						xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-						xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
-						xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<channel-type id="hvac-working">
 		<item-type>Switch</item-type>
 		<label>Working</label>
 		<description>Gives you information if HVAC is working</description>
 		<category>Switch</category>
-		<state readOnly="true"/>
+		<state readOnly="true" />
 	</channel-type>
 
 	<channel-type id="hvac-mode">
@@ -36,7 +36,7 @@
 		<tags>
 			<tag>Setpoint</tag>
 		</tags>
-		<state pattern="%.1f %unit%"/>
+		<state pattern="%.1f %unit%" />
 	</channel-type>
 
 	<channel-type id="hvac-temperature-cool">
@@ -47,6 +47,6 @@
 		<tags>
 			<tag>Setpoint</tag>
 		</tags>
-		<state pattern="%.1f %unit%"/>
+		<state pattern="%.1f %unit%" />
 	</channel-type>
 </thing:thing-descriptions>

--- a/src/main/resources/OH-INF/thing/supla-cloud-bridge.xml
+++ b/src/main/resources/OH-INF/thing/supla-cloud-bridge.xml
@@ -1,32 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="supla"
-						xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-						xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
-						xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<bridge-type id="cloud-bridge">
 		<label>Supla Cloud</label>
 		<description>
-			This bridge allows OpenHAB to connect via REST API to Supla Cloud.&lt;br /&gt;
+			This bridge allows OpenHAB to connect via REST API to
+			Supla Cloud.&lt;br /&gt;
 			Please double check that
-			you enabled REST API in your server config.
+			you enabled REST API
+			in your server config.
 		</description>
 
 		<channels>
-			<channel id="address" typeId="address"/>
-			<channel id="api-version" typeId="api-version"/>
-			<channel id="cloud-version" typeId="cloud-version"/>
+			<channel id="address" typeId="address" />
+			<channel id="api-version" typeId="api-version" />
+			<channel id="cloud-version" typeId="cloud-version" />
 
-			<channel id="api-calls" typeId="api-calls"/>
-			<channel id="remaining-api-calls" typeId="remaining-api-calls"/>
-			<channel id="api-calls-percentage" typeId="api-calls-percentage"/>
-			<channel id="remaining-api-calls-percentage" typeId="remaining-api-calls-percentage"/>
-			<channel id="rate-limit-max" typeId="rate-limit-max"/>
-			<channel id="rate-limit-reset-date-time" typeId="rate-limit-reset-date-time"/>
+			<channel id="api-calls" typeId="api-calls" />
+			<channel id="remaining-api-calls"
+				typeId="remaining-api-calls" />
+			<channel id="api-calls-percentage"
+				typeId="api-calls-percentage" />
+			<channel id="remaining-api-calls-percentage"
+				typeId="remaining-api-calls-percentage" />
+			<channel id="rate-limit-max" typeId="rate-limit-max" />
+			<channel id="rate-limit-reset-date-time"
+				typeId="rate-limit-reset-date-time" />
 
-			<channel id="req-per-s" typeId="req-per-x"/>
-			<channel id="req-per-m" typeId="req-per-x"/>
-			<channel id="req-per-h" typeId="req-per-x"/>
+			<channel id="req-per-s" typeId="req-per-x" />
+			<channel id="req-per-m" typeId="req-per-x" />
+			<channel id="req-per-h" typeId="req-per-x" />
 		</channels>
 
 		<representation-property>oAuthToken</representation-property>
@@ -39,19 +45,24 @@
 					]]></description>
 				<context>password</context>
 			</parameter>
-			<parameter name="refreshInterval" type="integer" required="false" min="1" unit="s">
+			<parameter name="refreshInterval" type="integer"
+				required="false" min="1" unit="s">
 				<label>Refresh Interval</label>
 				<description>Refresh time in seconds.</description>
 				<default>30</default>
 			</parameter>
-			<parameter name="cacheEvict" type="integer" required="false" unit="s">
+			<parameter name="cacheEvict" type="integer"
+				required="false" unit="s">
 				<label>Cache Evict</label>
-				<description>How long should cache store values from API (seconds). Setting this to value ≤ 0 will turn off caches
-					(you probably don't want to do this, because it will drain your API query limit)</description>
+				<description>How long should cache store values from API (seconds).
+					Setting this to value ≤ 0 will turn off caches
+					(you probably don't
+					want to do this, because it will drain your API query limit)</description>
 				<default>30</default>
 				<advanced>true</advanced>
 			</parameter>
-			<parameter name="refreshHandlerInterval" type="integer" required="false" min="1" unit="s">
+			<parameter name="refreshHandlerInterval" type="integer"
+				required="false" min="1" unit="s">
 				<label>Refresh Interval for Handler</label>
 				<description>Refresh Cloud Handler time in seconds.</description>
 				<default>600</default>
@@ -64,51 +75,51 @@
 	<channel-type id="address">
 		<item-type>String</item-type>
 		<label>Supla Cloud Address</label>
-		<state readOnly="true"/>
+		<state readOnly="true" />
 	</channel-type>
 	<channel-type id="api-version">
 		<item-type>String</item-type>
 		<label>API Version</label>
-		<state readOnly="true"/>
+		<state readOnly="true" />
 	</channel-type>
 	<channel-type id="cloud-version">
 		<item-type>String</item-type>
 		<label>Cloud Version</label>
-		<state readOnly="true"/>
+		<state readOnly="true" />
 	</channel-type>
 	<channel-type id="api-calls">
 		<item-type>Number</item-type>
 		<label>Used API calls (in last hour)</label>
-		<state readOnly="true"/>
+		<state readOnly="true" />
 	</channel-type>
 	<channel-type id="remaining-api-calls">
 		<item-type>Number</item-type>
 		<label>Remaining API calls</label>
-		<state readOnly="true"/>
+		<state readOnly="true" />
 	</channel-type>
 	<channel-type id="api-calls-percentage">
 		<item-type>Number</item-type>
 		<label>Percentage of used API calls (in last hour)</label>
-		<state readOnly="true"/>
+		<state readOnly="true" />
 	</channel-type>
 	<channel-type id="remaining-api-calls-percentage">
 		<item-type>Number</item-type>
 		<label>Remaining percentage API calls</label>
-		<state readOnly="true"/>
+		<state readOnly="true" />
 	</channel-type>
 	<channel-type id="rate-limit-max">
 		<item-type>Number</item-type>
 		<label>Maximum API calls per hour</label>
-		<state readOnly="true"/>
+		<state readOnly="true" />
 	</channel-type>
 	<channel-type id="rate-limit-reset-date-time">
 		<item-type>String:Timestamp</item-type>
 		<label>Time when API calls will be reset</label>
-		<state readOnly="true"/>
+		<state readOnly="true" />
 	</channel-type>
 	<channel-type id="req-per-x">
 		<item-type>Number</item-type>
 		<label>Requests per ...</label>
-		<state readOnly="true"/>
+		<state readOnly="true" />
 	</channel-type>
 </thing:thing-descriptions>

--- a/src/main/resources/OH-INF/thing/supla-gateway-device.xml
+++ b/src/main/resources/OH-INF/thing/supla-gateway-device.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="supla"
-						xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-						xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
-						xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<bridge-type id="gateway-device">
 		<supported-bridge-type-refs>
-			<bridge-type-ref id="server-bridge"/>
+			<bridge-type-ref id="server-bridge" />
 		</supported-bridge-type-refs>
 		<label>Supla Gateway Bridge</label>
 		<description>
@@ -14,8 +14,10 @@
 		</description>
 
 		<channels>
-			<channel id="gateway-connected-devices" typeId="connected-devices">
-				<description>Indicates how many devices are connected to this gateway.</description>
+			<channel id="gateway-connected-devices"
+				typeId="connected-devices">
+				<description>Indicates how many devices are connected to this
+					gateway.</description>
 			</channel>
 		</channels>
 
@@ -23,27 +25,32 @@
 		<config-description>
 			<parameter name="guid" type="text" required="true">
 				<label>GUID</label>
-				<description>This is GUID of device. It can be found on website during device configuration.
+				<description>This is GUID of device. It can be found on website
+					during device configuration.
 				</description>
 			</parameter>
 
 			<parameter-group name="accessIdLogin">
 				<label>Access ID Login</label>
 				<description>
-					If you want to authenticate your devices with access ID flow fill
+					If you want to authenticate your devices with access ID
+					flow fill
 					&lt;strong&gt;both&lt;/strong&gt;
-					&lt;em&gt;Server Access ID&lt;/em&gt; and
-					&lt;em&gt;Server Access ID Password&lt;/em&gt;
-				</description>
+					&lt;em&gt;Server Access
+					ID&lt;/em&gt; and
+					&lt;em&gt;Server Access ID Password&lt;/em&gt; </description>
 			</parameter-group>
-			<parameter name="serverAccessId" type="integer" min="1" groupName="accessIdLogin">
+			<parameter name="serverAccessId" type="integer" min="1"
+				groupName="accessIdLogin">
 				<label>Server Access ID</label>
 				<description>
-					This is ID that devices will use to register to your server.
+					This is ID that devices will use to register to your
+					server.
 				</description>
 				<advanced>true</advanced>
 			</parameter>
-			<parameter name="serverAccessIdPassword" type="text" groupName="accessIdLogin">
+			<parameter name="serverAccessIdPassword" type="text"
+				groupName="accessIdLogin">
 				<label>Server Access ID Password</label>
 				<description>
 					This is password required to register to your server.
@@ -55,23 +62,28 @@
 				<label>Email Login</label>
 				<context>email</context>
 				<description>
-					If you want to authenticate your devices with email/password flow fill
-					&lt;strong&gt;both&lt;/strong&gt; &lt;em&gt;Email&lt;/em&gt; and
-					&lt;em&gt;Email Password&lt;/em&gt;
-				</description>
+					If you want to authenticate your devices with
+					email/password flow fill
+					&lt;strong&gt;both&lt;/strong&gt;
+					&lt;em&gt;Email&lt;/em&gt; and
+					&lt;em&gt;Email Password&lt;/em&gt; </description>
 			</parameter-group>
-			<parameter name="email" type="text" min="1" groupName="emailIdLogin">
+			<parameter name="email" type="text" min="1"
+				groupName="emailIdLogin">
 				<label>Email</label>
 				<description>
-					This is email that devices will use to register to your server.&lt;br/&gt;
+					This is email that devices will use to register to your
+					server.&lt;br/&gt;
 					&lt;em&gt;This email address
-					does not need to be reachable. It won't be used in any way, i.e. to
-					send email to.&lt;/em&gt;
-				</description>
+					does not need to be
+					reachable. It won't be used in any way, i.e. to
+					send email
+					to.&lt;/em&gt; </description>
 				<context>email</context>
 				<advanced>true</advanced>
 			</parameter>
-			<parameter name="authKey" type="text" min="1" groupName="emailIdLogin">
+			<parameter name="authKey" type="text" min="1"
+				groupName="emailIdLogin">
 				<label>Auth Key</label>
 				<description>
 					Authentication key that device sends to authenticate.
@@ -81,17 +93,17 @@
 
 			<parameter name="timeout" type="text">
 				<label>Timeout</label>
-				<description/>
+				<description />
 				<advanced>true</advanced>
 			</parameter>
 			<parameter name="timeoutMin" type="text">
 				<label>Timeout Min</label>
-				<description/>
+				<description />
 				<advanced>true</advanced>
 			</parameter>
 			<parameter name="timeoutMax" type="text">
 				<label>Timeout Max</label>
-				<description/>
+				<description />
 				<advanced>true</advanced>
 			</parameter>
 		</config-description>
@@ -102,6 +114,6 @@
 		<item-type>Number</item-type>
 		<label>Connected devices</label>
 		<description>Indicates how many devices are connected to this server.</description>
-		<state readOnly="true" min="0"/>
+		<state readOnly="true" min="0" />
 	</channel-type>
 </thing:thing-descriptions>

--- a/src/main/resources/OH-INF/thing/supla-server-bridge.xml
+++ b/src/main/resources/OH-INF/thing/supla-server-bridge.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="supla"
-						xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-						xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
-						xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<bridge-type id="server-bridge">
 		<label>Supla Server</label>
@@ -11,7 +11,7 @@
 		</description>
 
 		<channels>
-			<channel id="server-devices" typeId="connected-devices"/>
+			<channel id="server-devices" typeId="connected-devices" />
 		</channels>
 
 		<representation-property>port</representation-property>
@@ -19,18 +19,23 @@
 			<parameter-group name="accessIdLogin">
 				<label>Access ID Login</label>
 				<description>
-					If you want to authenticate your devices with access ID flow fill
+					If you want to authenticate your devices with access ID
+					flow fill
 					&lt;strong&gt;both&lt;/strong&gt;
-					&lt;em&gt;Server Access ID&lt;/em&gt; and
+					&lt;em&gt;Server Access
+					ID&lt;/em&gt; and
 					&lt;em&gt;Server Access ID Password&lt;/em&gt; </description>
 			</parameter-group>
-			<parameter name="serverAccessId" type="integer" min="1" groupName="accessIdLogin">
+			<parameter name="serverAccessId" type="integer" min="1"
+				groupName="accessIdLogin">
 				<label>Server Access ID</label>
 				<description>
-					This is ID that devices will use to register to your server.
+					This is ID that devices will use to register to your
+					server.
 				</description>
 			</parameter>
-			<parameter name="serverAccessIdPassword" type="text" groupName="accessIdLogin">
+			<parameter name="serverAccessIdPassword" type="text"
+				groupName="accessIdLogin">
 				<label>Server Access ID Password</label>
 				<description>
 					This is password required to register to your server.
@@ -40,20 +45,27 @@
 			<parameter-group name="emailIdLogin">
 				<label>Email Login</label>
 				<description>
-					If you want to authenticate your devices with email/password flow fill
-					&lt;strong&gt;both&lt;/strong&gt; &lt;em&gt;Email&lt;/em&gt; and
+					If you want to authenticate your devices with
+					email/password flow fill
+					&lt;strong&gt;both&lt;/strong&gt;
+					&lt;em&gt;Email&lt;/em&gt; and
 					&lt;em&gt;Email Password&lt;/em&gt; </description>
 			</parameter-group>
-			<parameter name="email" type="text" min="1" groupName="emailIdLogin">
+			<parameter name="email" type="text" min="1"
+				groupName="emailIdLogin">
 				<label>Email</label>
 				<description>
-					This is email that devices will use to register to your server.&lt;br/&gt;
+					This is email that devices will use to register to your
+					server.&lt;br/&gt;
 					&lt;em&gt;This email address
-					does not need to be reachable. It won't be used in any way, i.e. to
-					send email to.&lt;/em&gt; </description>
+					does not need to be
+					reachable. It won't be used in any way, i.e. to
+					send email
+					to.&lt;/em&gt; </description>
 				<context>email</context>
 			</parameter>
-			<parameter name="authKey" type="text" min="1" groupName="emailIdLogin">
+			<parameter name="authKey" type="text" min="1"
+				groupName="emailIdLogin">
 				<label>Auth Key</label>
 				<description>
 					Authentication key that device sends to authenticate.
@@ -61,7 +73,8 @@
 				<advanced>true</advanced>
 			</parameter>
 
-			<parameter name="port" type="integer" required="true" min="1">
+			<parameter name="port" type="integer" required="true"
+				min="1">
 				<label>Server port</label>
 				<description>
 					<![CDATA[
@@ -76,7 +89,7 @@
 				<default>2016</default>
 			</parameter>
 
-			<parameter name="ssl" type="boolean" >
+			<parameter name="ssl" type="boolean">
 				<label>Enable SSL</label>
 				<description><![CDATA[
 					Enable SSL in server. <br>
@@ -98,21 +111,24 @@
 					Setup timeouts for all devices
 				</description>
 			</parameter-group>
-			<parameter name="timeout" type="text" required="true" groupName="gTimeout">
+			<parameter name="timeout" type="text" required="true"
+				groupName="gTimeout">
 				<label>Timeout</label>
-				<description/>
+				<description />
 				<advanced>true</advanced>
 				<default>10</default>
 			</parameter>
-			<parameter name="timeoutMin" type="text" required="true" groupName="gTimeout">
+			<parameter name="timeoutMin" type="text" required="true"
+				groupName="gTimeout">
 				<label>Timeout Min</label>
-				<description/>
+				<description />
 				<advanced>true</advanced>
 				<default>8</default>
 			</parameter>
-			<parameter name="timeoutMax" type="text" required="true" groupName="gTimeout">
+			<parameter name="timeoutMax" type="text" required="true"
+				groupName="gTimeout">
 				<label>Timeout Max</label>
-				<description/>
+				<description />
 				<advanced>true</advanced>
 				<default>12</default>
 			</parameter>
@@ -124,6 +140,6 @@
 		<item-type>Number</item-type>
 		<label>Connected devices</label>
 		<description>Indicates how many devices are connected to this server.</description>
-		<state readOnly="true" min="0"/>
+		<state readOnly="true" min="0" />
 	</channel-type>
 </thing:thing-descriptions>

--- a/src/main/resources/OH-INF/thing/supla-server-subdevice.xml
+++ b/src/main/resources/OH-INF/thing/supla-server-subdevice.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="supla"
-						xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-						xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
-						xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<thing-type id="sub-device-device">
 		<supported-bridge-type-refs>
-			<bridge-type-ref id="gateway-device"/>
+			<bridge-type-ref id="gateway-device" />
 		</supported-bridge-type-refs>
 		<label>Supla Native Server Sub Device</label>
 		<description>

--- a/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/src/main/resources/OH-INF/thing/thing-types.xml
@@ -1,42 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="supla"
-						xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-						xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
-						xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="https://openhab.org/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/thing-description/v1.0.0 https://openhab.org/schemas/thing-description-1.0.0.xsd">
 
 	<thing-type id="server-device">
 		<supported-bridge-type-refs>
-			<bridge-type-ref id="server-bridge"/>
-			<bridge-type-ref id="gateway-device"/>
+			<bridge-type-ref id="server-bridge" />
+			<bridge-type-ref id="gateway-device" />
 		</supported-bridge-type-refs>
 		<label>Supla Native Server Device</label>
-		<description>Generic type for all Supla devices. Channels will be provided by device at runtime</description>
+		<description>Generic type for all Supla devices. Channels will be
+			provided by device at runtime</description>
 		<!-- Note: Channels will be discovered at runtime -->
 		<representation-property>guid</representation-property>
 		<config-description>
 			<parameter name="guid" type="text" required="true">
 				<label>GUID</label>
-				<description>This is GUID of device. It can be found on website during device configuration.
+				<description>This is GUID of device. It can be found on website
+					during device configuration.
 				</description>
 			</parameter>
 
 			<parameter-group name="accessIdLogin">
 				<label>Access ID Login</label>
 				<description>
-					If you want to authenticate your devices with access ID flow fill
+					If you want to authenticate your devices with access ID
+					flow fill
 					&lt;strong&gt;both&lt;/strong&gt;
-					&lt;em&gt;Server Access ID&lt;/em&gt; and
-					&lt;em&gt;Server Access ID Password&lt;/em&gt;
-				</description>
+					&lt;em&gt;Server Access
+					ID&lt;/em&gt; and
+					&lt;em&gt;Server Access ID Password&lt;/em&gt; </description>
 			</parameter-group>
-			<parameter name="serverAccessId" type="integer" min="1" groupName="accessIdLogin">
+			<parameter name="serverAccessId" type="integer" min="1"
+				groupName="accessIdLogin">
 				<label>Server Access ID</label>
 				<description>
-					This is ID that devices will use to register to your server.
+					This is ID that devices will use to register to your
+					server.
 				</description>
 				<advanced>true</advanced>
 			</parameter>
-			<parameter name="serverAccessIdPassword" type="text" groupName="accessIdLogin">
+			<parameter name="serverAccessIdPassword" type="text"
+				groupName="accessIdLogin">
 				<label>Server Access ID Password</label>
 				<description>
 					This is password required to register to your server.
@@ -48,23 +54,28 @@
 				<label>Email Login</label>
 				<context>email</context>
 				<description>
-					If you want to authenticate your devices with email/password flow fill
-					&lt;strong&gt;both&lt;/strong&gt; &lt;em&gt;Email&lt;/em&gt; and
-					&lt;em&gt;Email Password&lt;/em&gt;
-				</description>
+					If you want to authenticate your devices with
+					email/password flow fill
+					&lt;strong&gt;both&lt;/strong&gt;
+					&lt;em&gt;Email&lt;/em&gt; and
+					&lt;em&gt;Email Password&lt;/em&gt; </description>
 			</parameter-group>
-			<parameter name="email" type="text" min="1" groupName="emailIdLogin">
+			<parameter name="email" type="text" min="1"
+				groupName="emailIdLogin">
 				<label>Email</label>
 				<description>
-					This is email that devices will use to register to your server.&lt;br/&gt;
+					This is email that devices will use to register to your
+					server.&lt;br/&gt;
 					&lt;em&gt;This email address
-					does not need to be reachable. It won't be used in any way, i.e. to
-					send email to.&lt;/em&gt;
-				</description>
+					does not need to be
+					reachable. It won't be used in any way, i.e. to
+					send email
+					to.&lt;/em&gt; </description>
 				<context>email</context>
 				<advanced>true</advanced>
 			</parameter>
-			<parameter name="authKey" type="text" min="1" groupName="emailIdLogin">
+			<parameter name="authKey" type="text" min="1"
+				groupName="emailIdLogin">
 				<label>Auth Key</label>
 				<description>
 					Authentication key that device sends to authenticate.
@@ -74,134 +85,136 @@
 
 			<parameter name="timeout" type="text">
 				<label>Timeout</label>
-				<description/>
+				<description />
 				<advanced>true</advanced>
 			</parameter>
 			<parameter name="timeoutMin" type="text">
 				<label>Timeout Min</label>
-				<description/>
+				<description />
 				<advanced>true</advanced>
 			</parameter>
 			<parameter name="timeoutMax" type="text">
 				<label>Timeout Max</label>
-				<description/>
+				<description />
 				<advanced>true</advanced>
 			</parameter>
 		</config-description>
 	</thing-type>
 	<thing-type id="cloud-device">
 		<supported-bridge-type-refs>
-			<bridge-type-ref id="cloud-bridge"/>
+			<bridge-type-ref id="cloud-bridge" />
 		</supported-bridge-type-refs>
 		<label>Supla Cloud Device</label>
-		<description>Generic type for all Supla devices. Channels will be provided by device at runtime</description>
+		<description>Generic type for all Supla devices. Channels will be
+			provided by device at runtime</description>
 		<!-- Note: Channels will be discovered at runtime -->
 		<representation-property>Supla-device-guid</representation-property>
 		<config-description>
-			<parameter name="cloud-id" type="integer" required="false" min="1">
+			<parameter name="cloud-id" type="integer" required="false"
+				min="1">
 				<label>Cloud ID</label>
 				<description>ID of device in Supla Cloud.</description>
 			</parameter>
 		</config-description>
 	</thing-type>
 
-		<channel-type id="light-channel">
-				<item-type>Switch</item-type>
-				<label>%channel-type.supla.light-channel.label</label>
-				<description>%channel-type.supla.light-channel.description</description>
-				<category>Light</category>
-		</channel-type>
+	<channel-type id="light-channel">
+		<item-type>Switch</item-type>
+		<label>%channel-type.supla.light-channel.label</label>
+		<description>%channel-type.supla.light-channel.description</description>
+		<category>Light</category>
+	</channel-type>
 
-		<channel-type id="switch-channel">
-				<item-type>Switch</item-type>
-				<label>%channel-type.supla.switch-channel.label</label>
-				<description>%channel-type.supla.switch-channel.description</description>
-				<category>Switch</category>
-		</channel-type>
+	<channel-type id="switch-channel">
+		<item-type>Switch</item-type>
+		<label>%channel-type.supla.switch-channel.label</label>
+		<description>%channel-type.supla.switch-channel.description</description>
+		<category>Switch</category>
+	</channel-type>
 
-		<channel-type id="switch-channel-ro">
-				<item-type>Switch</item-type>
-				<label>%channel-type.supla.switch-channel-ro.label</label>
-				<description>%channel-type.supla.switch-channel-ro.description</description>
-				<category>Switch</category>
-				<state readOnly="true"/>
-		</channel-type>
+	<channel-type id="switch-channel-ro">
+		<item-type>Switch</item-type>
+		<label>%channel-type.supla.switch-channel-ro.label</label>
+		<description>%channel-type.supla.switch-channel-ro.description</description>
+		<category>Switch</category>
+		<state readOnly="true" />
+	</channel-type>
 
-		<channel-type id="flag-channel" advanced="true">
-				<item-type>Switch</item-type>
-				<label>%channel-type.supla.flag-channel.label</label>
-				<description>%channel-type.supla.flag-channel.description</description>
-				<category>Switch</category>
-				<state readOnly="true"/>
-		</channel-type>
+	<channel-type id="flag-channel" advanced="true">
+		<item-type>Switch</item-type>
+		<label>%channel-type.supla.flag-channel.label</label>
+		<description>%channel-type.supla.flag-channel.description</description>
+		<category>Switch</category>
+		<state readOnly="true" />
+	</channel-type>
 
-		<channel-type id="decimal-channel">
-				<item-type>Number</item-type>
-				<label>%channel-type.supla.decimal-channel.label</label>
-				<description>%channel-type.supla.decimal-channel.description</description>
-				<state readOnly="true"/>
-		</channel-type>
+	<channel-type id="decimal-channel">
+		<item-type>Number</item-type>
+		<label>%channel-type.supla.decimal-channel.label</label>
+		<description>%channel-type.supla.decimal-channel.description</description>
+		<state readOnly="true" />
+	</channel-type>
 
-		<channel-type id="energy-channel">
-				<item-type>Number:Energy</item-type>
-				<label>%channel-type.supla.energy-channel.label</label>
-				<state readOnly="true" pattern="%.2f kWh"/>
-		</channel-type>
+	<channel-type id="energy-channel">
+		<item-type>Number:Energy</item-type>
+		<label>%channel-type.supla.energy-channel.label</label>
+		<state readOnly="true" pattern="%.2f kWh" />
+	</channel-type>
 
-		<channel-type id="power-channel">
-				<item-type>Number:Power</item-type>
-				<label>%channel-type.supla.power-channel.label</label>
-				<state readOnly="true" pattern="%.2f W"/>
-		</channel-type>
+	<channel-type id="power-channel">
+		<item-type>Number:Power</item-type>
+		<label>%channel-type.supla.power-channel.label</label>
+		<state readOnly="true" pattern="%.2f W" />
+	</channel-type>
 
-		<channel-type id="voltage-channel">
-				<item-type>Number:ElectricPotential</item-type>
-				<label>%channel-type.supla.voltage-channel.label</label>
-				<description>%channel-type.supla.voltage-channel.description</description>
-				<state readOnly="true" pattern="%.2f V"/>
-		</channel-type>
+	<channel-type id="voltage-channel">
+		<item-type>Number:ElectricPotential</item-type>
+		<label>%channel-type.supla.voltage-channel.label</label>
+		<description>%channel-type.supla.voltage-channel.description</description>
+		<state readOnly="true" pattern="%.2f V" />
+	</channel-type>
 
-		<channel-type id="current-channel">
-				<item-type>Number:ElectricCurrent</item-type>
-				<label>%channel-type.supla.current-channel.label</label>
-				<description>%channel-type.supla.current-channel.description</description>
-				<state readOnly="true" pattern="%.2f A"/>
-		</channel-type>
+	<channel-type id="current-channel">
+		<item-type>Number:ElectricCurrent</item-type>
+		<label>%channel-type.supla.current-channel.label</label>
+		<description>%channel-type.supla.current-channel.description</description>
+		<state readOnly="true" pattern="%.2f A" />
+	</channel-type>
 
-		<channel-type id="frequency-channel">
-				<item-type>Number:Frequency</item-type>
-				<label>%channel-type.supla.frequency-channel.label</label>
-				<description>%channel-type.supla.frequency-channel.description</description>
-				<state readOnly="true" pattern="%.2f Hz"/>
-		</channel-type>
+	<channel-type id="frequency-channel">
+		<item-type>Number:Frequency</item-type>
+		<label>%channel-type.supla.frequency-channel.label</label>
+		<description>%channel-type.supla.frequency-channel.description</description>
+		<state readOnly="true" pattern="%.2f Hz" />
+	</channel-type>
 
-		<channel-type id="percentage-channel">
-				<item-type>Number</item-type>
-				<label>%channel-type.supla.percentage-channel.label</label>
-				<state readOnly="true"/>
-		</channel-type>
+	<channel-type id="percentage-channel">
+		<item-type>Number</item-type>
+		<label>%channel-type.supla.percentage-channel.label</label>
+		<state readOnly="true" />
+	</channel-type>
 
-		<channel-type id="rgb-channel">
-				<item-type>Color</item-type>
-				<label>%channel-type.supla.rgb-channel.label</label>
-				<description>%channel-type.supla.rgb-channel.description</description>
-		</channel-type>
+	<channel-type id="rgb-channel">
+		<item-type>Color</item-type>
+		<label>%channel-type.supla.rgb-channel.label</label>
+		<description>%channel-type.supla.rgb-channel.description</description>
+	</channel-type>
 
-		<channel-type id="roller-shutter-channel">
-				<item-type>Rollershutter</item-type>
-				<label>%channel-type.supla.roller-shutter-channel.label</label>
-		</channel-type>
+	<channel-type id="roller-shutter-channel">
+		<item-type>Rollershutter</item-type>
+		<label>%channel-type.supla.roller-shutter-channel.label</label>
+	</channel-type>
 
-		<channel-type id="temperature-channel">
-				<item-type>Number:Temperature</item-type>
-				<label>%channel-type.supla.temperature-channel.label</label>
-				<category>Temperature</category>
-			<tags>
-				<tag>Temperature</tag>
-				<tag>Measurement</tag>
-			</tags>
-				<state readOnly="true" pattern="%.1f %unit%"/>
-		</channel-type>
+	<channel-type id="temperature-channel">
+		<item-type>Number:Temperature</item-type>
+		<label>%channel-type.supla.temperature-channel.label</label>
+		<category>Temperature</category>
+		<tags>
+			<tag>Temperature</tag>
+			<tag>Measurement</tag>
+		</tags>
+		<state readOnly="true" pattern="%.1f %unit%" />
+	</channel-type>
 
 	<channel-type id="pressure-channel">
 		<item-type>Number:Pressure</item-type>
@@ -211,7 +224,7 @@
 			<tag>Pressure</tag>
 			<tag>Measurement</tag>
 		</tags>
-		<state readOnly="true" pattern="%.1f %unit%"/>
+		<state readOnly="true" pattern="%.1f %unit%" />
 	</channel-type>
 
 	<channel-type id="rain-channel">
@@ -222,7 +235,7 @@
 			<tag>Rain</tag>
 			<tag>Measurement</tag>
 		</tags>
-		<state readOnly="true" pattern="%.1f %unit%"/>
+		<state readOnly="true" pattern="%.1f %unit%" />
 	</channel-type>
 
 	<channel-type id="weight-channel">
@@ -232,7 +245,7 @@
 		<tags>
 			<tag>Measurement</tag>
 		</tags>
-		<state readOnly="true" pattern="%.1f %unit%"/>
+		<state readOnly="true" pattern="%.1f %unit%" />
 	</channel-type>
 
 	<channel-type id="wind-channel">
@@ -243,46 +256,46 @@
 			<tag>Wind</tag>
 			<tag>Measurement</tag>
 		</tags>
-		<state readOnly="true" pattern="%.1f %unit%"/>
+		<state readOnly="true" pattern="%.1f %unit%" />
 	</channel-type>
 
-		<channel-type id="humidity-channel">
-				<item-type unitHint="%">Number:Dimensionless</item-type>
-				<label>%channel-type.supla.humidity-channel.label</label>
-			<category>Humidity</category>
-			<tags>
-						<tag>Humidity</tag>
-						<tag>Measurement</tag>
+	<channel-type id="humidity-channel">
+		<item-type unitHint="%">Number:Dimensionless</item-type>
+		<label>%channel-type.supla.humidity-channel.label</label>
+		<category>Humidity</category>
+		<tags>
+			<tag>Humidity</tag>
+			<tag>Measurement</tag>
 		</tags>
-			<state readOnly="true" min="0" max="100" pattern="%.1f %unit%"/>
+		<state readOnly="true" min="0" max="100" pattern="%.1f %unit%" />
 	</channel-type>
 
-		<channel-type id="dimmer-channel">
-				<item-type>Dimmer</item-type>
-				<label>%channel-type.supla.dimmer-channel.label</label>
-		</channel-type>
+	<channel-type id="dimmer-channel">
+		<item-type>Dimmer</item-type>
+		<label>%channel-type.supla.dimmer-channel.label</label>
+	</channel-type>
 
-		<channel-type id="toggle-gate-channel">
-				<item-type>Switch</item-type>
-				<label>%channel-type.supla.toggle-gate-channel.label</label>
-		</channel-type>
+	<channel-type id="toggle-gate-channel">
+		<item-type>Switch</item-type>
+		<label>%channel-type.supla.toggle-gate-channel.label</label>
+	</channel-type>
 
-		<channel-type id="string-channel">
-				<item-type>String</item-type>
-				<label>%channel-type.supla.string-channel.label</label>
-				<state readOnly="true"/>
-		</channel-type>
+	<channel-type id="string-channel">
+		<item-type>String</item-type>
+		<label>%channel-type.supla.string-channel.label</label>
+		<state readOnly="true" />
+	</channel-type>
 
-		<channel-type id="action-trigger">
-				<kind>TRIGGER</kind>
-				<label>%channel-type.supla.action-trigger.label</label>
-				<description>%channel-type.supla.action-trigger.description</description>
-				<category>Button</category>
-		</channel-type>
+	<channel-type id="action-trigger">
+		<kind>TRIGGER</kind>
+		<label>%channel-type.supla.action-trigger.label</label>
+		<description>%channel-type.supla.action-trigger.description</description>
+		<category>Button</category>
+	</channel-type>
 
-		<channel-type id="unknown-channel">
-				<item-type>String</item-type>
-				<label>%channel-type.supla.unknown-channel.label</label>
-				<description>%channel-type.supla.unknown-channel.description</description>
-		</channel-type>
+	<channel-type id="unknown-channel">
+		<item-type>String</item-type>
+		<label>%channel-type.supla.unknown-channel.label</label>
+		<description>%channel-type.supla.unknown-channel.description</description>
+	</channel-type>
 </thing:thing-descriptions>


### PR DESCRIPTION
### Motivation
- Ensure consistent formatting for XML resource files under `src/*/resources` using Spotless. 
- Prevent the generic Spotless formatter from double-formatting XML by excluding those files from the generic format rule. 
- Keep repository formatting rules aligned with CI requirements that run Spotless on compile.

### Description
- Update `pom.xml` to exclude `src/*/resources/**/*.xml` from the generic format and add a dedicated Spotless `<format>` that applies `eclipseWtp` XML formatting to `src/*/resources/**/*.xml`.
- Apply the new formatter to reformat resource XML files (OH-INF thing/binding/addon descriptors and the integration-test `logback-test.xml`).
- No behavioral or Java source changes were introduced; this is purely formatting/configuration.

### Testing
- Ran `mvn spotless:apply` which completed successfully and reformatted the targeted XML files. 
- Ran `mvn test` which completed successfully and reported all tests passing (`Tests run: 126, Failures: 0, Errors: 0, Skipped: 0`).
- Spotless checks (`spotless:check`) were exercised as part of `mvn test`/build and passed after formatting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69639dcb74508320ad14f03b4b00c98f)