### PR TITLE
Add Celsius units to Heatpol thermostat updates

### DIFF
--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/ChannelValueToState.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/ChannelValueToState.java
@@ -73,10 +73,10 @@ public class ChannelValueToState {
                 new ChannelState(new ChannelUID(channelGroupUid, "on"), OnOffType.from(value.on())),
                 new ChannelState(
                         new ChannelUID(channelGroupUid, "measuredTemperature"),
-                        new DecimalType(value.measuredTemperature())),
+                        new QuantityType<>(value.measuredTemperature(), CELSIUS)),
                 new ChannelState(
                         new ChannelUID(channelGroupUid, "presetTemperature"),
-                        new DecimalType(value.presetTemperature())));
+                        new QuantityType<>(value.presetTemperature(), CELSIUS)));
         return Stream.concat(basicStream, flagsStream);
     }
 


### PR DESCRIPTION
### Motivation
- Heatpol thermostat temperatures were emitted as dimensionless `DecimalType`, preventing OpenHAB from recognizing `Number:Temperature` channels and performing unit-aware conversions. 
- Measurements and presets must carry a temperature unit so OpenHAB treats them as `QuantityType` values.

### Description
- Emit Heatpol `measuredTemperature` and `presetTemperature` as `QuantityType<>(..., CELSIUS)` in `ChannelValueToState` (`src/main/java/.../ChannelValueToState.java`).
- Add a unit test `shouldUseCelsiusForHeatpolThermostatTemperatures` to `ChannelValueToStateTest` to verify both measured and preset temperatures carry the Celsius unit (`src/test/java/.../ChannelValueToStateTest.java`).
- Formatting updated with `spotless` as part of the change.

### Testing
- Ran `mvn spotless:apply` to ensure code formatting, which completed successfully. 
- Ran `mvn test`, all tests passed (`Tests run: 131, Failures: 0, Errors: 0, Skipped: 0`, build succeeded).
- Added unit test for Heatpol thermostat temperatures which passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963a6c5d4d483208a7ab436a6fba843)