### PR TITLE
ci: upload test reports from workflows

### DIFF
--- a/.github/workflows/maven-main.yml
+++ b/.github/workflows/maven-main.yml
@@ -50,7 +50,15 @@ jobs:
       - name: Build with Maven
         run: mvn -B -ntp spotless:check verify --file pom.xml
 
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports-${{ github.job }}
+          path: |
+            target/surefire-reports/**
+            target/failsafe-reports/**
+
       # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
       - name: Maven Dependency Tree Dependency Submission
         uses: advanced-security/maven-dependency-submission-action@v4.0.2
-

--- a/.github/workflows/maven-pr.yml
+++ b/.github/workflows/maven-pr.yml
@@ -16,4 +16,11 @@ jobs:
           cache: maven
       - name: Build with Maven
         run: mvn -B -ntp spotless:check verify
-
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports-${{ github.job }}
+          path: |
+            target/surefire-reports/**
+            target/failsafe-reports/**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,14 @@ jobs:
         env:
           GITHUB_USERNAME: x-access-token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports-${{ github.job }}
+          path: |
+            target/surefire-reports/**
+            target/failsafe-reports/**
       - name: Download latest open-hab
         id: config
         run: |


### PR DESCRIPTION
### Motivation
- Ensure surefire/failsafe test reports are retained as artifacts for PR and master CI runs to aid debugging of failures.
- Provide test report artifacts from the release workflow so release validation output is available after execution.
- Make test results available even when jobs fail by using `if: always()` on upload steps.

### Description
- Added an `Upload test reports` step to `.github/workflows/maven-pr.yml` that uses `actions/upload-artifact@v4` to upload `target/surefire-reports/**` and `target/failsafe-reports/**`.
- Added the same upload step to the `build` job in `.github/workflows/maven-main.yml` to publish reports from master builds.
- Added the same upload step to `.github/workflows/release.yml` after the Maven release step to collect release test reports.
- Each upload step is guarded with `if: always()` so artifacts are uploaded regardless of build outcome.

### Testing
- Ran `mvn spotless:apply` locally and it completed successfully.
- Ran `mvn test` locally and the test suite completed successfully (BUILD SUCCESS).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963af04611c83209670aef0f2856fd0)