### PR TITLE
Make action timeouts configurable and use millisecond-based waits

### DIFF
--- a/src/main/java/pl/grzeslowski/openhab/supla/actions/SuplaServerDeviceActions.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/actions/SuplaServerDeviceActions.java
@@ -3,7 +3,7 @@ package pl.grzeslowski.openhab.supla.actions;
 import static java.lang.System.arraycopy;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static pl.grzeslowski.jsupla.protocol.api.CalCfgCommand.*;
 import static pl.grzeslowski.jsupla.protocol.api.CalCfgResult.SUPLA_CALCFG_RESULT_DONE;
 import static pl.grzeslowski.jsupla.protocol.api.DeviceFlag.SUPLA_DEVICE_FLAG_AUTOMATIC_FIRMWARE_UPDATE_SUPPORTED;
@@ -132,8 +132,9 @@ public class SuplaServerDeviceActions implements ThingActions {
         if (writer == null) {
             throw new IllegalStateException("There is no socket writer!");
         }
-        writer.write(message).await(30, SECONDS);
-        var deviceConfigResult = localHandler.listenForSetDeviceConfigResult(30, SECONDS);
+        var timeout = localHandler.getConfiguration().getSetDeviceConfigActionTimeout();
+        writer.write(message).await(timeout.toMillis(), MILLISECONDS);
+        var deviceConfigResult = localHandler.listenForSetDeviceConfigResult(timeout.toMillis(), MILLISECONDS);
         var result = DeviceConfigResult.findConfigResult(deviceConfigResult.result());
         if (!result.isSuccess()) {
             throw new RuntimeException("Setting device config did not succeed! configs=%s. %s"
@@ -205,9 +206,10 @@ public class SuplaServerDeviceActions implements ThingActions {
                 EMPTY_DATA.length,
                 EMPTY_DATA);
         localHandler.clearDeviceCalCfgResult();
-        writer.write(message).await(30, SECONDS);
+        var timeout = localHandler.getConfiguration().getResetElectricMeterCountersActionTimeout();
+        writer.write(message).await(timeout.toMillis(), MILLISECONDS);
 
-        var result = localHandler.listenForDeviceCalCfgResult(30, SECONDS);
+        var result = localHandler.listenForDeviceCalCfgResult(timeout.toMillis(), MILLISECONDS);
         if (result.channelNumber() != channelNumber) {
             throw new RuntimeException("Reset counters returned a different channel number! request=%s, result=%s"
                     .formatted(message, result));
@@ -254,9 +256,10 @@ public class SuplaServerDeviceActions implements ThingActions {
                 EMPTY_DATA.length,
                 EMPTY_DATA);
         localHandler.clearDeviceCalCfgResult();
-        writer.write(message).await(30, SECONDS);
+        var timeout = localHandler.getConfiguration().getEnterConfigModeActionTimeout();
+        writer.write(message).await(timeout.toMillis(), MILLISECONDS);
 
-        var result = localHandler.listenForDeviceCalCfgResult(30, SECONDS);
+        var result = localHandler.listenForDeviceCalCfgResult(timeout.toMillis(), MILLISECONDS);
         if (result.channelNumber() != NOT_BOUND_TO_CHANNEL) {
             throw new RuntimeException("Enter config mode returned a different channel number! request=%s, result=%s"
                     .formatted(message, result));
@@ -292,9 +295,10 @@ public class SuplaServerDeviceActions implements ThingActions {
 
         localHandler.clearDeviceCalCfgResult();
         localHandler.markOtaCheckPending();
-        writer.write(message).await(30, SECONDS);
+        var timeout = localHandler.getConfiguration().getCheckFirmwareUpdateActionTimeout();
+        writer.write(message).await(timeout.toMillis(), MILLISECONDS);
 
-        var result = localHandler.listenForDeviceCalCfgResult(30, SECONDS);
+        var result = localHandler.listenForDeviceCalCfgResult(timeout.toMillis(), MILLISECONDS);
         if (result.channelNumber() != NOT_BOUND_TO_CHANNEL) {
             localHandler.markOtaCheckError();
             throw new RuntimeException(
@@ -312,7 +316,9 @@ public class SuplaServerDeviceActions implements ThingActions {
                     "Check firmware update did not succeed! request=%s, result=%s".formatted(message, result));
         }
 
-        return localHandler.listenForOtaCheckResult(30, SECONDS).name();
+        return localHandler
+                .listenForOtaCheckResult(timeout.toMillis(), MILLISECONDS)
+                .name();
     }
 
     @RuleAction(
@@ -332,6 +338,14 @@ public class SuplaServerDeviceActions implements ThingActions {
     private String sendWholeDeviceCalCfgCommand(CalCfgCommand command, String actionName)
             throws InterruptedException, TimeoutException {
         var localHandler = requireOtaReadyHandler();
+        var timeout =
+                switch (command) {
+                    case SUPLA_CALCFG_CMD_START_FIRMWARE_UPDATE ->
+                        localHandler.getConfiguration().getStartFirmwareUpdateActionTimeout();
+                    case SUPLA_CALCFG_CMD_START_SECURITY_UPDATE ->
+                        localHandler.getConfiguration().getStartSecurityUpdateActionTimeout();
+                    default -> localHandler.getConfiguration().getActionTimeout();
+                };
         var writer = localHandler.getWriter().get();
         if (writer == null) {
             throw new IllegalStateException("There is no socket writer!");
@@ -346,9 +360,9 @@ public class SuplaServerDeviceActions implements ThingActions {
                 EMPTY_DATA.length,
                 EMPTY_DATA);
         localHandler.clearDeviceCalCfgResult();
-        writer.write(message).await(30, SECONDS);
+        writer.write(message).await(timeout.toMillis(), MILLISECONDS);
 
-        var result = localHandler.listenForDeviceCalCfgResult(30, SECONDS);
+        var result = localHandler.listenForDeviceCalCfgResult(timeout.toMillis(), MILLISECONDS);
         if (result.channelNumber() != NOT_BOUND_TO_CHANNEL) {
             throw new RuntimeException("%s returned a different channel number! request=%s, result=%s"
                     .formatted(actionName, message, result));

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandler.java
@@ -137,6 +137,9 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
     private ServerBridge bridgeHandler;
 
     @Getter
+    private ServerDeviceHandlerConfiguration configuration = new ServerDeviceHandlerConfiguration();
+
+    @Getter
     private final AtomicReference<@Nullable SuplaWriter> writer = new AtomicReference<>();
 
     private final AtomicReference<@Nullable SetDeviceConfigResult> setDeviceConfigResult = new AtomicReference<>();
@@ -192,7 +195,7 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
         }
         var localBridgeHandler = this.bridgeHandler = (ServerBridge) rawBridgeHandler;
 
-        var config = getConfigAs(ServerDeviceHandlerConfiguration.class);
+        var config = this.configuration = getConfigAs(ServerDeviceHandlerConfiguration.class);
         guid = config.getGuid();
         if (guid == null || guid.isEmpty()) {
             guid = null;

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/oh_config/ServerDeviceHandlerConfiguration.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/oh_config/ServerDeviceHandlerConfiguration.java
@@ -8,6 +8,8 @@ import org.eclipse.jdt.annotation.Nullable;
 
 @Data
 public class ServerDeviceHandlerConfiguration {
+    private static final Duration DEFAULT_ACTION_TIMEOUT = Duration.ofSeconds(30);
+
     @Nullable
     private String guid;
 
@@ -33,6 +35,27 @@ public class ServerDeviceHandlerConfiguration {
     @Nullable
     private String timeoutMax;
 
+    @Nullable
+    private String actionTimeout = DEFAULT_ACTION_TIMEOUT.toString();
+
+    @Nullable
+    private String setDeviceConfigActionTimeout;
+
+    @Nullable
+    private String resetElectricMeterCountersActionTimeout;
+
+    @Nullable
+    private String enterConfigModeActionTimeout;
+
+    @Nullable
+    private String checkFirmwareUpdateActionTimeout;
+
+    @Nullable
+    private String startFirmwareUpdateActionTimeout;
+
+    @Nullable
+    private String startSecurityUpdateActionTimeout;
+
     public Duration getTimeout() {
         return TimeoutConfiguration.tryParseDuration(timeout).orElse(null);
     }
@@ -43,5 +66,39 @@ public class ServerDeviceHandlerConfiguration {
 
     public Duration getTimeoutMax() {
         return TimeoutConfiguration.tryParseDuration(timeoutMax).orElse(null);
+    }
+
+    public Duration getActionTimeout() {
+        return TimeoutConfiguration.tryParseDuration(actionTimeout).orElse(DEFAULT_ACTION_TIMEOUT);
+    }
+
+    public Duration getSetDeviceConfigActionTimeout() {
+        return TimeoutConfiguration.tryParseDuration(setDeviceConfigActionTimeout)
+                .orElseGet(this::getActionTimeout);
+    }
+
+    public Duration getResetElectricMeterCountersActionTimeout() {
+        return TimeoutConfiguration.tryParseDuration(resetElectricMeterCountersActionTimeout)
+                .orElseGet(this::getActionTimeout);
+    }
+
+    public Duration getEnterConfigModeActionTimeout() {
+        return TimeoutConfiguration.tryParseDuration(enterConfigModeActionTimeout)
+                .orElseGet(this::getActionTimeout);
+    }
+
+    public Duration getCheckFirmwareUpdateActionTimeout() {
+        return TimeoutConfiguration.tryParseDuration(checkFirmwareUpdateActionTimeout)
+                .orElseGet(this::getActionTimeout);
+    }
+
+    public Duration getStartFirmwareUpdateActionTimeout() {
+        return TimeoutConfiguration.tryParseDuration(startFirmwareUpdateActionTimeout)
+                .orElseGet(this::getActionTimeout);
+    }
+
+    public Duration getStartSecurityUpdateActionTimeout() {
+        return TimeoutConfiguration.tryParseDuration(startSecurityUpdateActionTimeout)
+                .orElseGet(this::getActionTimeout);
     }
 }

--- a/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/src/main/resources/OH-INF/thing/thing-types.xml
@@ -98,6 +98,92 @@
 				<description />
 				<advanced>true</advanced>
 			</parameter>
+			<parameter name="actionTimeout" type="text">
+				<label>Action Timeout</label>
+				<description>
+					Timeout for all actions. Supported formats:
+					&lt;em&gt;seconds&lt;/em&gt; as integer/decimal
+					(e.g. 30, 1.5) or
+					&lt;em&gt;ISO-8601 duration&lt;/em&gt; (e.g. PT30S).
+				</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="setDeviceConfigActionTimeout" type="text">
+				<label>Set Device Config Action Timeout</label>
+				<description>
+					Overrides Action Timeout for
+					&lt;em&gt;Set Device
+					Config&lt;/em&gt; action.
+					Supported formats: seconds as
+					integer/decimal
+					(e.g. 30, 1.5) or ISO-8601 duration (e.g. PT30S).
+				</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="resetElectricMeterCountersActionTimeout"
+				type="text">
+				<label>Reset Electricity Meter Counters Action Timeout</label>
+				<description>
+					Overrides Action Timeout for
+					&lt;em&gt;Reset Electricity
+					Meter Counters&lt;/em&gt;
+					action. Supported formats: seconds as
+					integer/decimal
+					(e.g. 30, 1.5) or ISO-8601 duration (e.g. PT30S).
+				</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="enterConfigModeActionTimeout" type="text">
+				<label>Enter Config Mode Action Timeout</label>
+				<description>
+					Overrides Action Timeout for
+					&lt;em&gt;Enter Config
+					Mode&lt;/em&gt; action.
+					Supported formats: seconds as
+					integer/decimal
+					(e.g. 30, 1.5) or ISO-8601 duration (e.g. PT30S).
+				</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="checkFirmwareUpdateActionTimeout"
+				type="text">
+				<label>Check Firmware Update Action Timeout</label>
+				<description>
+					Overrides Action Timeout for
+					&lt;em&gt;Check Firmware
+					Update&lt;/em&gt; action.
+					Supported formats: seconds as
+					integer/decimal
+					(e.g. 30, 1.5) or ISO-8601 duration (e.g. PT30S).
+				</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="startFirmwareUpdateActionTimeout"
+				type="text">
+				<label>Start Firmware Update Action Timeout</label>
+				<description>
+					Overrides Action Timeout for
+					&lt;em&gt;Start Firmware
+					Update&lt;/em&gt; action.
+					Supported formats: seconds as
+					integer/decimal
+					(e.g. 30, 1.5) or ISO-8601 duration (e.g. PT30S).
+				</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="startSecurityUpdateActionTimeout"
+				type="text">
+				<label>Start Security Update Action Timeout</label>
+				<description>
+					Overrides Action Timeout for
+					&lt;em&gt;Start Security
+					Update&lt;/em&gt; action.
+					Supported formats: seconds as
+					integer/decimal
+					(e.g. 30, 1.5) or ISO-8601 duration (e.g. PT30S).
+				</description>
+				<advanced>true</advanced>
+			</parameter>
 		</config-description>
 	</thing-type>
 	<thing-type id="cloud-device">

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/SuplaServerDeviceActionsTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/SuplaServerDeviceActionsTest.java
@@ -1,6 +1,6 @@
 package pl.grzeslowski.openhab.supla.internal.server;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -34,6 +34,7 @@ import pl.grzeslowski.jsupla.protocol.api.structs.sd.DeviceCalCfgRequest;
 import pl.grzeslowski.jsupla.server.SuplaWriter;
 import pl.grzeslowski.openhab.supla.actions.SuplaServerDeviceActions;
 import pl.grzeslowski.openhab.supla.internal.server.handler.ServerSuplaDeviceHandler;
+import pl.grzeslowski.openhab.supla.internal.server.oh_config.ServerDeviceHandlerConfiguration;
 import pl.grzeslowski.openhab.supla.internal.server.traits.SuplaDevice;
 
 @ExtendWith(MockitoExtension.class)
@@ -50,16 +51,19 @@ class SuplaServerDeviceActionsTest {
     @InjectMocks
     private SuplaServerDeviceActions actions;
 
+    private ServerDeviceHandlerConfiguration configuration;
     private ChannelFuture successfulFuture;
 
     @BeforeEach
     void setUp() {
         var channel = new EmbeddedChannel();
         successfulFuture = new DefaultChannelPromise(channel).setSuccess(null);
+        configuration = new ServerDeviceHandlerConfiguration();
 
         actions.setThingHandler(handler);
         org.mockito.Mockito.lenient().when(handler.getWriter()).thenReturn(new AtomicReference<>(writer));
         org.mockito.Mockito.lenient().when(handler.getThing()).thenReturn(thing);
+        org.mockito.Mockito.lenient().when(handler.getConfiguration()).thenReturn(configuration);
         org.mockito.Mockito.lenient().when(thing.getUID()).thenReturn(new ThingUID("supla:test:1"));
         org.mockito.Mockito.lenient().when(thing.getStatus()).thenReturn(ONLINE);
         org.mockito.Mockito.lenient()
@@ -88,7 +92,7 @@ class SuplaServerDeviceActionsTest {
 
     @Test
     void shouldSendResetCountersRequest() throws Exception {
-        when(handler.listenForDeviceCalCfgResult(30, SECONDS))
+        when(handler.listenForDeviceCalCfgResult(30_000, MILLISECONDS))
                 .thenReturn(new DeviceCalCfgResult(
                         0,
                         7,
@@ -114,7 +118,7 @@ class SuplaServerDeviceActionsTest {
 
     @Test
     void shouldFailWhenDeviceRejectsResetCounters() throws Exception {
-        when(handler.listenForDeviceCalCfgResult(30, SECONDS))
+        when(handler.listenForDeviceCalCfgResult(30_000, MILLISECONDS))
                 .thenReturn(new DeviceCalCfgResult(
                         0,
                         7,
@@ -144,7 +148,7 @@ class SuplaServerDeviceActionsTest {
 
     @Test
     void shouldSendResetCountersRequestForChannelNumber() throws Exception {
-        when(handler.listenForDeviceCalCfgResult(30, SECONDS))
+        when(handler.listenForDeviceCalCfgResult(30_000, MILLISECONDS))
                 .thenReturn(new DeviceCalCfgResult(
                         0,
                         7,
@@ -179,7 +183,7 @@ class SuplaServerDeviceActionsTest {
 
     @Test
     void shouldSendEnterConfigModeRequest() throws Exception {
-        when(handler.listenForDeviceCalCfgResult(30, SECONDS))
+        when(handler.listenForDeviceCalCfgResult(30_000, MILLISECONDS))
                 .thenReturn(new DeviceCalCfgResult(
                         0,
                         -1,
@@ -216,7 +220,7 @@ class SuplaServerDeviceActionsTest {
 
     @Test
     void shouldFailWhenDeviceRejectsEnterConfigMode() throws Exception {
-        when(handler.listenForDeviceCalCfgResult(30, SECONDS))
+        when(handler.listenForDeviceCalCfgResult(30_000, MILLISECONDS))
                 .thenReturn(new DeviceCalCfgResult(
                         0,
                         -1,
@@ -259,7 +263,7 @@ class SuplaServerDeviceActionsTest {
 
     @Test
     void shouldSendCheckFirmwareUpdateRequest() throws Exception {
-        when(handler.listenForDeviceCalCfgResult(30, SECONDS))
+        when(handler.listenForDeviceCalCfgResult(30_000, MILLISECONDS))
                 .thenReturn(new DeviceCalCfgResult(
                         0,
                         -1,
@@ -267,7 +271,8 @@ class SuplaServerDeviceActionsTest {
                         SUPLA_CALCFG_RESULT_DONE.getValue(),
                         0L,
                         new byte[0]));
-        when(handler.listenForOtaCheckResult(30, SECONDS)).thenReturn(ServerSuplaDeviceHandler.OtaStatus.AVAILABLE);
+        when(handler.listenForOtaCheckResult(30_000, MILLISECONDS))
+                .thenReturn(ServerSuplaDeviceHandler.OtaStatus.AVAILABLE);
 
         assertThat(actions.checkFirmwareUpdate()).isEqualTo("AVAILABLE");
 
@@ -278,13 +283,13 @@ class SuplaServerDeviceActionsTest {
                 .write(argThat(proto -> proto instanceof DeviceCalCfgRequest request
                         && request.channelNumber() == -1
                         && request.command() == SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue()));
-        inOrder.verify(handler).listenForDeviceCalCfgResult(30, SECONDS);
-        inOrder.verify(handler).listenForOtaCheckResult(30, SECONDS);
+        inOrder.verify(handler).listenForDeviceCalCfgResult(30_000, MILLISECONDS);
+        inOrder.verify(handler).listenForOtaCheckResult(30_000, MILLISECONDS);
     }
 
     @Test
     void shouldSendStartFirmwareUpdateRequest() throws Exception {
-        when(handler.listenForDeviceCalCfgResult(30, SECONDS))
+        when(handler.listenForDeviceCalCfgResult(30_000, MILLISECONDS))
                 .thenReturn(new DeviceCalCfgResult(
                         0,
                         -1,
@@ -306,7 +311,7 @@ class SuplaServerDeviceActionsTest {
 
     @Test
     void shouldSendStartSecurityUpdateRequest() throws Exception {
-        when(handler.listenForDeviceCalCfgResult(30, SECONDS))
+        when(handler.listenForDeviceCalCfgResult(30_000, MILLISECONDS))
                 .thenReturn(new DeviceCalCfgResult(
                         0,
                         -1,

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/oh_config/ServerDeviceHandlerConfigurationTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/oh_config/ServerDeviceHandlerConfigurationTest.java
@@ -1,0 +1,44 @@
+package pl.grzeslowski.openhab.supla.internal.server.oh_config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class ServerDeviceHandlerConfigurationTest {
+    @Test
+    void shouldUse30SecondsAsDefaultActionTimeout() {
+        var configuration = new ServerDeviceHandlerConfiguration();
+
+        assertThat(configuration.getActionTimeout()).isEqualTo(Duration.ofSeconds(30));
+        assertThat(configuration.getSetDeviceConfigActionTimeout()).isEqualTo(Duration.ofSeconds(30));
+        assertThat(configuration.getResetElectricMeterCountersActionTimeout()).isEqualTo(Duration.ofSeconds(30));
+        assertThat(configuration.getEnterConfigModeActionTimeout()).isEqualTo(Duration.ofSeconds(30));
+        assertThat(configuration.getCheckFirmwareUpdateActionTimeout()).isEqualTo(Duration.ofSeconds(30));
+        assertThat(configuration.getStartFirmwareUpdateActionTimeout()).isEqualTo(Duration.ofSeconds(30));
+        assertThat(configuration.getStartSecurityUpdateActionTimeout()).isEqualTo(Duration.ofSeconds(30));
+    }
+
+    @Test
+    void shouldUseMainActionTimeoutWhenSpecificOneIsNotSet() {
+        var configuration = new ServerDeviceHandlerConfiguration();
+        configuration.setActionTimeout("PT42S");
+
+        assertThat(configuration.getActionTimeout()).isEqualTo(Duration.ofSeconds(42));
+        assertThat(configuration.getSetDeviceConfigActionTimeout()).isEqualTo(Duration.ofSeconds(42));
+        assertThat(configuration.getResetElectricMeterCountersActionTimeout()).isEqualTo(Duration.ofSeconds(42));
+        assertThat(configuration.getEnterConfigModeActionTimeout()).isEqualTo(Duration.ofSeconds(42));
+        assertThat(configuration.getCheckFirmwareUpdateActionTimeout()).isEqualTo(Duration.ofSeconds(42));
+        assertThat(configuration.getStartFirmwareUpdateActionTimeout()).isEqualTo(Duration.ofSeconds(42));
+        assertThat(configuration.getStartSecurityUpdateActionTimeout()).isEqualTo(Duration.ofSeconds(42));
+    }
+
+    @Test
+    void shouldUseSpecificActionTimeoutWhenSet() {
+        var configuration = new ServerDeviceHandlerConfiguration();
+        configuration.setActionTimeout("PT42S");
+        configuration.setSetDeviceConfigActionTimeout("PT4S");
+
+        assertThat(configuration.getSetDeviceConfigActionTimeout()).isEqualTo(Duration.ofSeconds(4));
+    }
+}


### PR DESCRIPTION
### Motivation
- Replace hard-coded 30-second action waits with configurable timeouts per device handler to allow finer control and avoid long waits. 
- Use millisecond-based waits for Netty futures to align with `Duration`-based configuration values. 
- Expose per-action timeout overrides in the thing configuration so specific actions can have shorter or longer timeouts than the global action timeout.

### Description
- Replaced uses of `SECONDS` waits with `MILLISECONDS` and changed call sites to use timeouts from `ServerDeviceHandlerConfiguration` instead of fixed 30 seconds in `SuplaServerDeviceActions`. 
- Added `ServerDeviceHandlerConfiguration` fields for `actionTimeout` plus specific overrides (`setDeviceConfigActionTimeout`, `resetElectricMeterCountersActionTimeout`, `enterConfigModeActionTimeout`, `checkFirmwareUpdateActionTimeout`, `startFirmwareUpdateActionTimeout`, `startSecurityUpdateActionTimeout`) with getters that return `Duration` and default to 30s when unspecified. 
- Plumbed the configuration into `ServerSuplaDeviceHandler` during initialization by storing `configuration` from `getConfigAs(...)`. 
- Extended `OH-INF/thing/thing-types.xml` to document the new `actionTimeout` parameter and per-action override parameters. 
- Updated unit tests in `SuplaServerDeviceActionsTest` to assert millisecond-based waits and added `ServerDeviceHandlerConfigurationTest` to verify default and override behavior for action timeouts.

### Testing
- Updated and ran `SuplaServerDeviceActionsTest`, which now expects `listenForDeviceCalCfgResult` and `listenForOtaCheckResult` calls with millisecond timeouts; tests passed. 
- Added and ran `ServerDeviceHandlerConfigurationTest` to validate default 30s behavior and override semantics for `getActionTimeout()` and specific getters; tests passed. 
- Ran the unit test suite (`mvn test`) and all modified/added tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef360043a08320819147ebd105cdbd)