### PR TITLE
Fix checkFirmwareUpdate timeout budgeting and OTA error handling

### DIFF
--- a/src/main/java/pl/grzeslowski/openhab/supla/actions/SuplaServerDeviceActions.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/actions/SuplaServerDeviceActions.java
@@ -4,6 +4,7 @@ import static java.lang.System.arraycopy;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static pl.grzeslowski.jsupla.protocol.api.CalCfgCommand.*;
 import static pl.grzeslowski.jsupla.protocol.api.CalCfgResult.SUPLA_CALCFG_RESULT_DONE;
 import static pl.grzeslowski.jsupla.protocol.api.DeviceFlag.SUPLA_DEVICE_FLAG_AUTOMATIC_FIRMWARE_UPDATE_SUPPORTED;
@@ -30,6 +31,7 @@ import org.openhab.core.thing.binding.ThingActionsScope;
 import org.openhab.core.thing.binding.ThingHandler;
 import pl.grzeslowski.jsupla.protocol.api.CalCfgCommand;
 import pl.grzeslowski.jsupla.protocol.api.DeviceConfigField;
+import pl.grzeslowski.jsupla.protocol.api.structs.ds.DeviceCalCfgResult;
 import pl.grzeslowski.jsupla.protocol.api.structs.sd.DeviceCalCfgRequest;
 import pl.grzeslowski.jsupla.protocol.api.structs.sd.SetDeviceConfig;
 import pl.grzeslowski.openhab.supla.internal.server.ChannelUtil;
@@ -296,9 +298,11 @@ public class SuplaServerDeviceActions implements ThingActions {
         localHandler.clearDeviceCalCfgResult();
         localHandler.markOtaCheckPending();
         var timeout = localHandler.getConfiguration().getCheckFirmwareUpdateActionTimeout();
+        var timeoutMillis = timeout.toMillis();
+        var checkFirmwareUpdateStart = System.nanoTime();
         try {
             var future = writer.write(message);
-            future.await(timeout.toMillis(), MILLISECONDS);
+            future.await(timeoutMillis, MILLISECONDS);
             if (!future.isSuccess()) {
                 throw new RuntimeException("Check firmware update dispatch failed! request=%s, cause=%s"
                         .formatted(message, future.cause()));
@@ -308,7 +312,13 @@ public class SuplaServerDeviceActions implements ThingActions {
             throw e;
         }
 
-        var result = localHandler.listenForDeviceCalCfgResult(timeout.toMillis(), MILLISECONDS);
+        DeviceCalCfgResult result;
+        try {
+            result = localHandler.listenForDeviceCalCfgResult(timeoutMillis, MILLISECONDS);
+        } catch (InterruptedException | TimeoutException | RuntimeException e) {
+            localHandler.markOtaCheckError();
+            throw e;
+        }
         if (result.channelNumber() != NOT_BOUND_TO_CHANNEL) {
             localHandler.markOtaCheckError();
             throw new RuntimeException(
@@ -326,9 +336,17 @@ public class SuplaServerDeviceActions implements ThingActions {
                     "Check firmware update did not succeed! request=%s, result=%s".formatted(message, result));
         }
 
-        return localHandler
-                .listenForOtaCheckResult(timeout.toMillis(), MILLISECONDS)
-                .name();
+        var checkFirmwareUpdateElapsed = System.nanoTime() - checkFirmwareUpdateStart;
+        var remainingTimeoutMillis =
+                Math.max(0L, timeoutMillis - MILLISECONDS.convert(checkFirmwareUpdateElapsed, NANOSECONDS));
+        try {
+            return localHandler
+                    .listenForOtaCheckResult(remainingTimeoutMillis, MILLISECONDS)
+                    .name();
+        } catch (InterruptedException | TimeoutException | RuntimeException e) {
+            localHandler.markOtaCheckError();
+            throw e;
+        }
     }
 
     @RuleAction(

--- a/src/main/java/pl/grzeslowski/openhab/supla/actions/SuplaServerDeviceActions.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/actions/SuplaServerDeviceActions.java
@@ -339,6 +339,10 @@ public class SuplaServerDeviceActions implements ThingActions {
         var checkFirmwareUpdateElapsed = System.nanoTime() - checkFirmwareUpdateStart;
         var remainingTimeoutMillis =
                 Math.max(0L, timeoutMillis - MILLISECONDS.convert(checkFirmwareUpdateElapsed, NANOSECONDS));
+        if (remainingTimeoutMillis <= 0) {
+            localHandler.markOtaCheckError();
+            throw new TimeoutException("Check firmware update timeout budget exhausted before OTA result wait");
+        }
         try {
             return localHandler
                     .listenForOtaCheckResult(remainingTimeoutMillis, MILLISECONDS)

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/SuplaServerDeviceActionsTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/SuplaServerDeviceActionsTest.java
@@ -315,6 +315,25 @@ class SuplaServerDeviceActionsTest {
     }
 
     @Test
+    void shouldFailImmediatelyWhenNoTimeoutBudgetRemainsForOtaCheck() throws Exception {
+        configuration.setCheckFirmwareUpdateActionTimeout("PT0S");
+        when(handler.listenForDeviceCalCfgResult(0, MILLISECONDS))
+                .thenReturn(new DeviceCalCfgResult(
+                        0,
+                        -1,
+                        SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue(),
+                        SUPLA_CALCFG_RESULT_DONE.getValue(),
+                        0L,
+                        new byte[0]));
+
+        assertThatThrownBy(() -> actions.checkFirmwareUpdate())
+                .isInstanceOf(TimeoutException.class)
+                .hasMessageContaining("timeout budget exhausted");
+        verify(handler, org.mockito.Mockito.never()).listenForOtaCheckResult(0, MILLISECONDS);
+        verify(handler).markOtaCheckError();
+    }
+
+    @Test
     void shouldMarkOtaCheckErrorWhenCheckFirmwareUpdateDispatchFails() {
         when(writer.write(argThat(proto -> proto instanceof DeviceCalCfgRequest)))
                 .thenThrow(new RuntimeException("dispatch failed"));

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/SuplaServerDeviceActionsTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/SuplaServerDeviceActionsTest.java
@@ -272,7 +272,9 @@ class SuplaServerDeviceActionsTest {
                         SUPLA_CALCFG_RESULT_DONE.getValue(),
                         0L,
                         new byte[0]));
-        when(handler.listenForOtaCheckResult(30_000, MILLISECONDS))
+        when(handler.listenForOtaCheckResult(
+                        org.mockito.ArgumentMatchers.longThat(timeout -> timeout > 0 && timeout <= 30_000),
+                        org.mockito.ArgumentMatchers.eq(MILLISECONDS)))
                 .thenReturn(ServerSuplaDeviceHandler.OtaStatus.AVAILABLE);
 
         assertThat(actions.checkFirmwareUpdate()).isEqualTo("AVAILABLE");
@@ -285,7 +287,10 @@ class SuplaServerDeviceActionsTest {
                         && request.channelNumber() == -1
                         && request.command() == SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue()));
         inOrder.verify(handler).listenForDeviceCalCfgResult(30_000, MILLISECONDS);
-        inOrder.verify(handler).listenForOtaCheckResult(30_000, MILLISECONDS);
+        inOrder.verify(handler)
+                .listenForOtaCheckResult(
+                        org.mockito.ArgumentMatchers.longThat(timeout -> timeout > 0 && timeout <= 30_000),
+                        org.mockito.ArgumentMatchers.eq(MILLISECONDS));
     }
 
     @Test
@@ -364,7 +369,10 @@ class SuplaServerDeviceActionsTest {
                         SUPLA_CALCFG_RESULT_DONE.getValue(),
                         0L,
                         new byte[0]));
-        when(handler.listenForOtaCheckResult(30_000, MILLISECONDS)).thenThrow(new TimeoutException("timeout"));
+        when(handler.listenForOtaCheckResult(
+                        org.mockito.ArgumentMatchers.longThat(timeout -> timeout > 0 && timeout <= 30_000),
+                        org.mockito.ArgumentMatchers.eq(MILLISECONDS)))
+                .thenThrow(new TimeoutException("timeout"));
 
         assertThatThrownBy(() -> actions.checkFirmwareUpdate()).isInstanceOf(TimeoutException.class);
         verify(handler).markOtaCheckError();

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/SuplaServerDeviceActionsTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/SuplaServerDeviceActionsTest.java
@@ -18,8 +18,10 @@ import static pl.grzeslowski.jsupla.protocol.api.DeviceFlag.SUPLA_DEVICE_FLAG_CA
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
+import java.time.Duration;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -288,6 +290,32 @@ class SuplaServerDeviceActionsTest {
     }
 
     @Test
+    void shouldUseRemainingTimeoutForOtaCheckResult() throws Exception {
+        configuration.setCheckFirmwareUpdateActionTimeout(Duration.ofMillis(100));
+        when(handler.listenForDeviceCalCfgResult(100, MILLISECONDS)).thenAnswer(invocation -> {
+            Thread.sleep(40);
+            return new DeviceCalCfgResult(
+                    0,
+                    -1,
+                    SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue(),
+                    SUPLA_CALCFG_RESULT_DONE.getValue(),
+                    0L,
+                    new byte[0]);
+        });
+        when(handler.listenForOtaCheckResult(
+                        org.mockito.ArgumentMatchers.longThat(timeout -> timeout < 100),
+                        org.mockito.ArgumentMatchers.eq(MILLISECONDS)))
+                .thenReturn(ServerSuplaDeviceHandler.OtaStatus.AVAILABLE);
+
+        assertThat(actions.checkFirmwareUpdate()).isEqualTo("AVAILABLE");
+
+        verify(handler)
+                .listenForOtaCheckResult(
+                        org.mockito.ArgumentMatchers.longThat(timeout -> timeout < 100),
+                        org.mockito.ArgumentMatchers.eq(MILLISECONDS));
+    }
+
+    @Test
     void shouldMarkOtaCheckErrorWhenCheckFirmwareUpdateDispatchFails() {
         when(writer.write(argThat(proto -> proto instanceof DeviceCalCfgRequest)))
                 .thenThrow(new RuntimeException("dispatch failed"));
@@ -297,6 +325,30 @@ class SuplaServerDeviceActionsTest {
                 .hasMessageContaining("dispatch failed");
         verify(handler).clearDeviceCalCfgResult();
         verify(handler).markOtaCheckPending();
+        verify(handler).markOtaCheckError();
+    }
+
+    @Test
+    void shouldMarkOtaCheckErrorWhenDeviceCalCfgResultWaitTimesOut() throws Exception {
+        when(handler.listenForDeviceCalCfgResult(30_000, MILLISECONDS)).thenThrow(new TimeoutException("timeout"));
+
+        assertThatThrownBy(() -> actions.checkFirmwareUpdate()).isInstanceOf(TimeoutException.class);
+        verify(handler).markOtaCheckError();
+    }
+
+    @Test
+    void shouldMarkOtaCheckErrorWhenOtaCheckWaitTimesOut() throws Exception {
+        when(handler.listenForDeviceCalCfgResult(30_000, MILLISECONDS))
+                .thenReturn(new DeviceCalCfgResult(
+                        0,
+                        -1,
+                        SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue(),
+                        SUPLA_CALCFG_RESULT_DONE.getValue(),
+                        0L,
+                        new byte[0]));
+        when(handler.listenForOtaCheckResult(30_000, MILLISECONDS)).thenThrow(new TimeoutException("timeout"));
+
+        assertThatThrownBy(() -> actions.checkFirmwareUpdate()).isInstanceOf(TimeoutException.class);
         verify(handler).markOtaCheckError();
     }
 

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/SuplaServerDeviceActionsTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/SuplaServerDeviceActionsTest.java
@@ -18,7 +18,6 @@ import static pl.grzeslowski.jsupla.protocol.api.DeviceFlag.SUPLA_DEVICE_FLAG_CA
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
-import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
@@ -291,7 +290,7 @@ class SuplaServerDeviceActionsTest {
 
     @Test
     void shouldUseRemainingTimeoutForOtaCheckResult() throws Exception {
-        configuration.setCheckFirmwareUpdateActionTimeout(Duration.ofMillis(100));
+        configuration.setCheckFirmwareUpdateActionTimeout("PT0.1S");
         when(handler.listenForDeviceCalCfgResult(100, MILLISECONDS)).thenAnswer(invocation -> {
             Thread.sleep(40);
             return new DeviceCalCfgResult(


### PR DESCRIPTION
### Motivation
- Prevent `checkFirmwareUpdate()` from consuming up to ~2× the configured timeout by enforcing a single overall timeout budget across the CALCFG wait and OTA wait phases.
- Ensure OTA state is cleaned up when either the CALCFG wait or the OTA wait fails or times out to avoid leaving handlers in a lingering CHECKING/PENDING state.

### Description
- Compute and record the overall timeout and start time, and pass only the remaining milliseconds to `listenForOtaCheckResult(...)` so both waits share one configured budget.
- Catch `InterruptedException`, `TimeoutException`, and `RuntimeException` from `listenForDeviceCalCfgResult(...)` and `listenForOtaCheckResult(...)`, call `markOtaCheckError()` before rethrowing, and preserve existing error handling for dispatch failures.
- Add `NANOSECONDS` import and a direct import for `DeviceCalCfgResult` used in the updated code.
- Add unit tests: `shouldUseRemainingTimeoutForOtaCheckResult`, `shouldMarkOtaCheckErrorWhenDeviceCalCfgResultWaitTimesOut`, and `shouldMarkOtaCheckErrorWhenOtaCheckWaitTimesOut` to cover the new timeout budgeting and error-cleanup behavior.

### Testing
- Ran `mvn spotless:apply` and formatting was applied successfully.
- Ran `mvn test` in this environment but the build failed during compilation with `java.lang.ExceptionInInitializerError: com.sun.tools.javac.code.TypeTag :: UNKNOWN`, so the full test suite could not complete here.
- The PR includes new unit tests exercising the remaining-time calculation and error-marking behavior (see test names above) which should be verified in CI where the project builds cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef4a0513d48320b111531788e17b43)