### PR TITLE
Generate SUPLA products catalog at build time and include product labels in discovery

### DIFF
--- a/bin/GenerateSuplaProductsCatalog.java
+++ b/bin/GenerateSuplaProductsCatalog.java
@@ -1,0 +1,262 @@
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+	public class GenerateSuplaProductsCatalog {
+	private static final String PRODUCTS_URL = "https://updates.supla.org/products";
+	private static final String PROTO_H_URL =
+			"https://raw.githubusercontent.com/SUPLA/supla-core/master/supla-common/proto.h";
+	private static final Pattern SUPLA_MFR_REGEX = Pattern.compile("#define\\s+(SUPLA_MFR_[A-Z0-9_]+)\\s+([0-9]+)");
+
+		private record ProductEntry(int manufacturerId, int productId, String manufacturer, String name) {}
+
+		public static void main(String[] args) throws IOException, InterruptedException {
+			String output = null;
+			boolean failOnNetworkError = false;
+			for (int i = 0; i < args.length - 1; i++) {
+				if ("--output".equals(args[i])) {
+					output = args[i + 1];
+				}
+				if ("--fail-on-network-error".equals(args[i])) {
+					failOnNetworkError = Boolean.parseBoolean(args[i + 1]);
+				}
+			}
+			if (output == null || output.isBlank()) {
+				throw new IllegalArgumentException("Missing required --output argument");
+			}
+
+			HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(30)).build();
+			List<ProductEntry> entries = fetchProducts(client, failOnNetworkError);
+			String javaContent = buildJavaContent(entries);
+
+		Path outputPath = Path.of(output);
+		Files.createDirectories(outputPath.getParent());
+			Files.writeString(outputPath, javaContent, StandardCharsets.UTF_8);
+			System.out.printf("Generated %s with %d product rows%n", outputPath, entries.size());
+		}
+
+		private static List<ProductEntry> fetchProducts(HttpClient client, boolean failOnNetworkError)
+				throws IOException, InterruptedException {
+			try {
+				String productsJson = fetch(client, PRODUCTS_URL);
+				String protoH = fetch(client, PROTO_H_URL);
+				Map<Integer, String> manufacturers = parseManufacturers(protoH);
+				return parseProducts(productsJson, manufacturers);
+			} catch (IOException | InterruptedException | RuntimeException ex) {
+				if (failOnNetworkError) {
+					throw ex;
+				}
+				System.err.printf("WARN: Could not fetch products catalog, generating empty map: %s%n", ex.getMessage());
+				return List.of();
+			}
+		}
+
+	private static String fetch(HttpClient client, String url) throws IOException, InterruptedException {
+		HttpRequest request = HttpRequest.newBuilder().GET().uri(URI.create(url)).timeout(Duration.ofSeconds(30)).build();
+		HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+		if (response.statusCode() != 200) {
+			throw new IllegalStateException("Failed to fetch %s, HTTP %d".formatted(url, response.statusCode()));
+		}
+		return response.body();
+	}
+
+	private static Map<Integer, String> parseManufacturers(String protoH) {
+		Map<Integer, String> manufacturers = new LinkedHashMap<>();
+		for (String line : protoH.split("\\R")) {
+			var match = SUPLA_MFR_REGEX.matcher(line);
+			if (!match.find()) {
+				continue;
+			}
+			var manufacturerName = match.group(1).replace("SUPLA_MFR_", "").replace("_", " ");
+			var manufacturerId = Integer.parseInt(match.group(2));
+			manufacturers.put(manufacturerId, manufacturerName);
+		}
+		return manufacturers;
+	}
+
+	private static List<ProductEntry> parseProducts(String productsJson, Map<Integer, String> manufacturers) {
+		List<ProductEntry> entries = new ArrayList<>();
+		for (String row : splitJsonRows(productsJson)) {
+			Integer manufacturerId = extractInt(row, "manufacturerId");
+			Integer productId = extractInt(row, "productId");
+			String productName = extractString(row, "productName");
+			if (manufacturerId == null || productId == null || productName == null) {
+				continue;
+			}
+			if (manufacturerId <= 0 || productId <= 0 || productName.isBlank()) {
+				continue;
+			}
+			String manufacturer = manufacturers.getOrDefault(manufacturerId, "UNKNOWN (%d)".formatted(manufacturerId));
+			entries.add(new ProductEntry(manufacturerId, productId, manufacturer, productName.trim()));
+		}
+		entries.sort(Comparator.comparingInt(ProductEntry::manufacturerId).thenComparingInt(ProductEntry::productId));
+		return entries;
+	}
+
+	private static List<String> splitJsonRows(String json) {
+		var rows = new ArrayList<String>();
+		boolean inString = false;
+		int depth = 0;
+		int start = -1;
+		for (int i = 0; i < json.length(); i++) {
+			char ch = json.charAt(i);
+			if (ch == '"' && (i == 0 || json.charAt(i - 1) != '\\')) {
+				inString = !inString;
+			}
+			if (inString) {
+				continue;
+			}
+			if (ch == '{') {
+				if (depth == 0) {
+					start = i;
+				}
+				depth++;
+			} else if (ch == '}') {
+				depth--;
+				if (depth == 0 && start >= 0) {
+					rows.add(json.substring(start, i + 1));
+				}
+			}
+		}
+		return rows;
+	}
+
+	private static Integer extractInt(String row, String key) {
+		var pattern = Pattern.compile("\"" + Pattern.quote(key) + "\"\\s*:\\s*(-?[0-9]+)");
+		var matcher = pattern.matcher(row);
+		if (!matcher.find()) {
+			return null;
+		}
+		return Integer.parseInt(matcher.group(1));
+	}
+
+	private static String extractString(String row, String key) {
+		var pattern = Pattern.compile("\"" + Pattern.quote(key) + "\"\\s*:\\s*\"((?:\\\\.|[^\\\\\"])*)\"");
+		var matcher = pattern.matcher(row);
+		if (!matcher.find()) {
+			return null;
+		}
+		return unescapeJsonString(matcher.group(1));
+	}
+
+	private static String unescapeJsonString(String value) {
+		var out = new StringBuilder();
+		for (int i = 0; i < value.length(); i++) {
+			char ch = value.charAt(i);
+			if (ch != '\\' || i + 1 >= value.length()) {
+				out.append(ch);
+				continue;
+			}
+			char escaped = value.charAt(++i);
+			switch (escaped) {
+				case '"':
+				case '\\':
+				case '/':
+					out.append(escaped);
+					break;
+				case 'b':
+					out.append('\b');
+					break;
+				case 'f':
+					out.append('\f');
+					break;
+				case 'n':
+					out.append('\n');
+					break;
+				case 'r':
+					out.append('\r');
+					break;
+				case 't':
+					out.append('\t');
+					break;
+				case 'u':
+					if (i + 4 >= value.length()) {
+						throw new IllegalArgumentException("Invalid unicode escape in JSON");
+					}
+					String code = value.substring(i + 1, i + 5);
+					out.append((char) Integer.parseInt(code, 16));
+					i += 4;
+					break;
+				default:
+					throw new IllegalArgumentException("Unsupported escape sequence: \\" + escaped);
+			}
+		}
+		return out.toString();
+	}
+
+	private static String buildJavaContent(List<ProductEntry> entries) {
+		var entriesCode = new StringBuilder();
+		for (int i = 0; i < entries.size(); i++) {
+			ProductEntry entry = entries.get(i);
+			entriesCode.append("            entry(new ProductKey(")
+					.append(entry.manufacturerId())
+					.append(", ")
+					.append(entry.productId())
+					.append("), new ProductInfo(")
+					.append(toJavaString(entry.manufacturer()))
+					.append(", ")
+					.append(toJavaString(entry.name()))
+					.append("))");
+			if (i < entries.size() - 1) {
+				entriesCode.append(",");
+			}
+			entriesCode.append(System.lineSeparator());
+		}
+
+		return """
+				package pl.grzeslowski.openhab.supla.internal.server.discovery;
+
+				import static java.util.Map.entry;
+
+				import java.util.Map;
+				import java.util.Optional;
+				import org.eclipse.jdt.annotation.NonNullByDefault;
+				import org.eclipse.jdt.annotation.Nullable;
+
+				@NonNullByDefault
+				public final class SuplaProductsCatalog {
+					private SuplaProductsCatalog() {}
+
+					public record ProductKey(int manufacturerId, int productId) {}
+
+					public record ProductInfo(String manufacturer, String name) {
+						public String description() {
+							var normalizedManufacturer = manufacturer.toLowerCase();
+							var normalizedName = name.toLowerCase();
+							if (normalizedName.startsWith(normalizedManufacturer + " ")) {
+								return name;
+							}
+							return manufacturer + " " + name;
+						}
+					}
+
+					private static final Map<ProductKey, ProductInfo> SUPLA_PRODUCTS = Map.ofEntries(
+				%s				    );
+
+					public static Optional<ProductInfo> findProductInfo(@Nullable Integer manufacturerId, @Nullable Integer productId) {
+						if (manufacturerId == null || productId == null || manufacturerId <= 0 || productId <= 0) {
+							return Optional.empty();
+						}
+						return Optional.ofNullable(SUPLA_PRODUCTS.get(new ProductKey(manufacturerId, productId)));
+					}
+				}
+				"""
+				.formatted(entriesCode);
+	}
+
+	private static String toJavaString(String value) {
+		return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
 
         <openhab.version>5.0.0</openhab.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <supla.products.failOnNetworkError>false</supla.products.failOnNetworkError>
     </properties>
 
     <dependencies>
@@ -427,6 +428,18 @@ pl.grzeslowski.openhab.supla.actions
                 <version>3.6.0</version>
                 <executions>
                     <execution>
+                        <id>add-generated-source</id>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <sources>
+                                <source>target/generated-sources/supla-products</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>add-integration-test-source</id>
                         <goals>
                             <goal>add-test-source</goal>
@@ -450,6 +463,30 @@ pl.grzeslowski.openhab.supla.actions
                                     <directory>src/integration-test/resources</directory>
                                 </resource>
                             </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.6.2</version>
+                <executions>
+                    <execution>
+                        <id>generate-supla-products-catalog</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <executable>java</executable>
+                            <arguments>
+                                <argument>${project.basedir}/bin/GenerateSuplaProductsCatalog.java</argument>
+                                <argument>--output</argument>
+                                <argument>${project.build.directory}/generated-sources/supla-products/pl/grzeslowski/openhab/supla/internal/server/discovery/SuplaProductsCatalog.java</argument>
+                                <argument>--fail-on-network-error</argument>
+                                <argument>${supla.products.failOnNetworkError}</argument>
+                            </arguments>
                         </configuration>
                     </execution>
                 </executions>
@@ -549,6 +586,9 @@ pl.grzeslowski.openhab.supla.actions
                     <value>true</value>
                 </property>
             </activation>
+            <properties>
+                <supla.products.failOnNetworkError>true</supla.products.failOnNetworkError>
+            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/discovery/ServerDiscoveryService.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/discovery/ServerDiscoveryService.java
@@ -80,8 +80,10 @@ public class ServerDiscoveryService extends AbstractDiscoveryService {
         var name = trait.name();
         var gateway = trait.channels().stream().anyMatch(c -> c.subDeviceId() != null && c.subDeviceId() > 0);
         var type = gateway ? SUPLA_GATEWAY_DEVICE_TYPE : SUPLA_SERVER_DEVICE_TYPE;
+        var productLabelSuffix = SuplaProductsCatalog.findProductInfo(trait.manufacturerId(), trait.productId())
+                .map(SuplaProductsCatalog.ProductInfo::description);
 
-        var builder = buildDiscoveryResult(SUPLA_DEVICE_GUID, guid, name, type);
+        var builder = buildDiscoveryResult(SUPLA_DEVICE_GUID, guid, name, type, productLabelSuffix);
         if (trait instanceof RegisterEmailDeviceTrait registerDevice) {
             var authKey = registerDevice.authKey();
             var serverName = registerDevice.serverName();
@@ -92,14 +94,23 @@ public class ServerDiscoveryService extends AbstractDiscoveryService {
     }
 
     private DiscoveryResult buildDiscoveryResult(int id, String name) {
-        return buildDiscoveryResult(SUPLA_SUB_DEVICE_ID, String.valueOf(id), name + " #" + id, SUPLA_SUB_DEVICE_TYPE)
+        return buildDiscoveryResult(
+                        SUPLA_SUB_DEVICE_ID,
+                        String.valueOf(id),
+                        name + " #" + id,
+                        SUPLA_SUB_DEVICE_TYPE,
+                        java.util.Optional.empty())
                 .build();
     }
 
     private DiscoveryResultBuilder buildDiscoveryResult(
-            String idKey, String id, @Nullable String name, ThingTypeUID type) {
+            String idKey,
+            String id,
+            @Nullable String name,
+            ThingTypeUID type,
+            java.util.Optional<String> productLabelSuffix) {
         var thingUID = new ThingUID(type, bridgeThingUID, id);
-        var label = buildLabel(id, name);
+        var label = buildLabel(id, name, productLabelSuffix);
         return DiscoveryResultBuilder.create(thingUID)
                 .withBridge(bridgeThingUID)
                 .withProperties(Map.of(idKey, id))
@@ -107,10 +118,14 @@ public class ServerDiscoveryService extends AbstractDiscoveryService {
                 .withLabel(label);
     }
 
-    private static String buildLabel(String guid, @Nullable String name) {
+    private static String buildLabel(
+            String guid, @Nullable String name, java.util.Optional<String> productLabelSuffix) {
+        var baseLabel = guid;
         if (name == null || name.isEmpty()) {
-            return guid;
+            baseLabel = guid;
+        } else {
+            baseLabel = name;
         }
-        return name;
+        return productLabelSuffix.map(suffix -> baseLabel + " (" + suffix + ")").orElse(baseLabel);
     }
 }

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/discovery/SuplaProductsCatalogTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/discovery/SuplaProductsCatalogTest.java
@@ -1,0 +1,28 @@
+package pl.grzeslowski.openhab.supla.internal.server.discovery;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class SuplaProductsCatalogTest {
+    @Test
+    void shouldResolveProductByManufacturerAndProductId() {
+        var product = SuplaProductsCatalog.findProductInfo(4, 9000);
+        var differentManufacturerSameProductId = SuplaProductsCatalog.findProductInfo(19, 1);
+
+        assertThat(product).isPresent();
+        assertThat(product.get().manufacturer()).isEqualTo("ZAMEL");
+        assertThat(product.get().name()).isEqualTo("ZAMEL mSLW-01");
+        assertThat(product.get().description()).isEqualTo("ZAMEL mSLW-01");
+        assertThat(differentManufacturerSameProductId).isPresent();
+        assertThat(differentManufacturerSameProductId.get().name())
+                .isNotEqualTo(product.get().name());
+    }
+
+    @Test
+    void shouldNotResolveWithMissingOrLegacyIds() {
+        assertThat(SuplaProductsCatalog.findProductInfo(null, 9000)).isEmpty();
+        assertThat(SuplaProductsCatalog.findProductInfo(4, null)).isEmpty();
+        assertThat(SuplaProductsCatalog.findProductInfo(0, 0)).isEmpty();
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide an up-to-date SUPLA products catalog generated from the upstream products JSON and `proto.h` so product names/manufacturers can be displayed. 
- Integrate the generator into the Maven build to produce a compile-time `SuplaProductsCatalog` class. 
- Surface product descriptions in discovery results so discovered devices show manufacturer/product info in labels.

### Description
- Add `bin/GenerateSuplaProductsCatalog.java`, a standalone generator that fetches `https://updates.supla.org/products` and the `proto.h` file, parses entries, and emits a `SuplaProductsCatalog` Java source file. 
- Update `pom.xml` to add a `supla.products.failOnNetworkError` property, include `target/generated-sources/supla-products` as a source root via `build-helper-maven-plugin`, and run the generator during `generate-sources` using `exec-maven-plugin`; the `release` profile forces failure on network errors. 
- Modify `ServerDiscoveryService` to consult `SuplaProductsCatalog.findProductInfo(manufacturerId, productId)` and append an optional product label suffix to discovery labels by extending `buildDiscoveryResult` and `buildLabel`. 
- Add unit test `SuplaProductsCatalogTest` to validate product lookup and handling of missing/legacy IDs.

### Testing
- Ran the Maven unit test lifecycle with `mvn test`, which executed the generation step and unit tests and completed successfully. 
- The new `SuplaProductsCatalogTest` ran and passed, verifying the lookup behavior and label description formatting. 
- Project compiles with the generated sources included and generator behavior is controlled by the `supla.products.failOnNetworkError` property.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f07b8fe6c48320a4e955bf48cdd4f5)