### PR TITLE
Remove dynamic Supla sender IDs

### DIFF
--- a/src/integration-test/java/pl/grzeslowski/openhab/supla/internal/SuplaServerActionsIT.java
+++ b/src/integration-test/java/pl/grzeslowski/openhab/supla/internal/SuplaServerActionsIT.java
@@ -17,6 +17,7 @@ import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.SUPLA_
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.SUPLA_SERVER_TYPE_ID;
 import static pl.grzeslowski.openhab.supla.internal.extension.supla.SuplaExtension.deviceInitialize;
 import static pl.grzeslowski.openhab.supla.internal.extension.supla.SuplaExtension.serverInitialize;
+import static pl.grzeslowski.openhab.supla.internal.server.handler.trait.ServerDevice.SENDER_ID;
 
 import io.github.glytching.junit.extension.random.RandomBeansExtension;
 import java.io.IOException;
@@ -87,11 +88,12 @@ class SuplaServerActionsIT {
             assertThat(request.channelNumber()).isEqualTo(-1);
             assertThat(request.command()).isEqualTo(SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue());
             assertThat(request.superUserAuthorized()).isEqualTo((byte) 1);
+            assertThat(request.senderId()).isEqualTo(SENDER_ID);
 
             consumeDeviceCalCfgResult(
                     deviceCtx.handler(),
                     new DeviceCalCfgResult(
-                            request.senderId(),
+                            request.receiverId(),
                             request.channelNumber(),
                             request.command(),
                             SUPLA_CALCFG_RESULT_DONE.getValue(),
@@ -102,7 +104,7 @@ class SuplaServerActionsIT {
             consumeDeviceCalCfgResult(
                     deviceCtx.handler(),
                     new DeviceCalCfgResult(
-                            request.senderId(),
+                            request.receiverId(),
                             request.channelNumber(),
                             request.command(),
                             SUPLA_CALCFG_RESULT_DONE.getValue(),
@@ -146,6 +148,7 @@ class SuplaServerActionsIT {
             var request = readDeviceCalCfgRequest(device::readDeviceCalCfgRequest);
             assertThat(request.channelNumber()).isEqualTo(-1);
             assertThat(request.command()).isEqualTo(SUPLA_CALCFG_CMD_START_FIRMWARE_UPDATE.getValue());
+            assertThat(request.senderId()).isEqualTo(SENDER_ID);
             consumeDeviceCalCfgResult(deviceCtx.handler(), request);
             assertThat(action.get(30, SECONDS)).isEqualTo(text("action.start-firmware-update.result.success"));
 
@@ -177,6 +180,7 @@ class SuplaServerActionsIT {
             var request = readDeviceCalCfgRequest(device::readDeviceCalCfgRequest);
             assertThat(request.channelNumber()).isEqualTo(-1);
             assertThat(request.command()).isEqualTo(SUPLA_CALCFG_CMD_START_SECURITY_UPDATE.getValue());
+            assertThat(request.senderId()).isEqualTo(SENDER_ID);
             consumeDeviceCalCfgResult(deviceCtx.handler(), request);
             assertThat(action.get(30, SECONDS)).isEqualTo(text("action.start-security-update.result.success"));
 
@@ -244,6 +248,7 @@ class SuplaServerActionsIT {
             assertThat(request.channelNumber()).isEqualTo(0);
             assertThat(request.command()).isEqualTo(SUPLA_CALCFG_CMD_RESET_COUNTERS.getValue());
             assertThat(request.superUserAuthorized()).isEqualTo((byte) 1);
+            assertThat(request.senderId()).isEqualTo(SENDER_ID);
             consumeDeviceCalCfgResult(deviceCtx.handler(), request);
             assertThat(action.get(30, SECONDS))
                     .isEqualTo(text("action.reset-electric-meter-counters.result.success", 0));
@@ -281,6 +286,7 @@ class SuplaServerActionsIT {
             assertThat(request.channelNumber()).isEqualTo(-1);
             assertThat(request.command()).isEqualTo(SUPLA_CALCFG_CMD_ENTER_CFG_MODE.getValue());
             assertThat(request.superUserAuthorized()).isEqualTo((byte) 1);
+            assertThat(request.senderId()).isEqualTo(SENDER_ID);
             consumeDeviceCalCfgResult(deviceCtx.handler(), request);
             assertThat(action.get(30, SECONDS)).isEqualTo(text("action.enter-config-mode.result.success"));
         }
@@ -304,15 +310,15 @@ class SuplaServerActionsIT {
         return actions;
     }
 
-    private static DeviceCalCfgRequest readDeviceCalCfgRequest(Supplier<DeviceCalCfgRequest> requestSupplier)
-            throws Exception {
+    private static DeviceCalCfgRequestWithMessageId readDeviceCalCfgRequest(
+            Supplier<DeviceCalCfgRequestWithMessageId> requestSupplier) throws Exception {
         return CompletableFuture.supplyAsync(requestSupplier).get(30, SECONDS);
     }
 
-    private static void consumeDeviceCalCfgResult(ThingHandler handler, DeviceCalCfgRequest request) {
+    private static void consumeDeviceCalCfgResult(ThingHandler handler, DeviceCalCfgRequestWithMessageId request) {
         ((ServerSuplaDeviceHandler) handler)
                 .consumeDeviceCalCfgResult(new DeviceCalCfgResult(
-                        request.senderId(),
+                        request.receiverId(),
                         request.channelNumber(),
                         request.command(),
                         SUPLA_CALCFG_RESULT_DONE.getValue(),
@@ -356,16 +362,46 @@ class SuplaServerActionsIT {
         awaitOnline(deviceCtx);
     }
 
+    private record DeviceCalCfgRequestWithMessageId(DeviceCalCfgRequest request, long messageId) {
+        private int receiverId() {
+            return (int) messageId;
+        }
+
+        private int senderId() {
+            return request.senderId();
+        }
+
+        private int channelNumber() {
+            return request.channelNumber();
+        }
+
+        private int command() {
+            return request.command();
+        }
+
+        private byte superUserAuthorized() {
+            return request.superUserAuthorized();
+        }
+
+        private long dataSize() {
+            return request.dataSize();
+        }
+
+        private byte[] data() {
+            return request.data();
+        }
+    }
+
     private static final class ActionAwareMew01 extends ZamelMew01 {
         private ActionAwareMew01(String guid, String email, String authKey) {
             super(guid, email, authKey);
         }
 
         @SneakyThrows
-        private DeviceCalCfgRequest readDeviceCalCfgRequest() {
-            var read = read();
-            assertThat(read).isInstanceOf(DeviceCalCfgRequest.class);
-            return (DeviceCalCfgRequest) read;
+        private DeviceCalCfgRequestWithMessageId readDeviceCalCfgRequest() {
+            var read = readWithMessageId();
+            assertThat(read.proto()).isInstanceOf(DeviceCalCfgRequest.class);
+            return new DeviceCalCfgRequestWithMessageId((DeviceCalCfgRequest) read.proto(), read.messageId());
         }
     }
 
@@ -375,10 +411,10 @@ class SuplaServerActionsIT {
         }
 
         @SneakyThrows
-        private DeviceCalCfgRequest readDeviceCalCfgRequest() {
-            var read = read();
-            assertThat(read).isInstanceOf(DeviceCalCfgRequest.class);
-            return (DeviceCalCfgRequest) read;
+        private DeviceCalCfgRequestWithMessageId readDeviceCalCfgRequest() {
+            var read = readWithMessageId();
+            assertThat(read.proto()).isInstanceOf(DeviceCalCfgRequest.class);
+            return new DeviceCalCfgRequestWithMessageId((DeviceCalCfgRequest) read.proto(), read.messageId());
         }
     }
 
@@ -410,10 +446,10 @@ class SuplaServerActionsIT {
         }
 
         @SneakyThrows
-        private DeviceCalCfgRequest readDeviceCalCfgRequest() {
-            var read = read();
-            assertThat(read).isInstanceOf(DeviceCalCfgRequest.class);
-            return (DeviceCalCfgRequest) read;
+        private DeviceCalCfgRequestWithMessageId readDeviceCalCfgRequest() {
+            var read = readWithMessageId();
+            assertThat(read.proto()).isInstanceOf(DeviceCalCfgRequest.class);
+            return new DeviceCalCfgRequestWithMessageId((DeviceCalCfgRequest) read.proto(), read.messageId());
         }
 
         @Override

--- a/src/integration-test/java/pl/grzeslowski/openhab/supla/internal/device/Device.java
+++ b/src/integration-test/java/pl/grzeslowski/openhab/supla/internal/device/Device.java
@@ -35,6 +35,8 @@ public abstract class Device implements AutoCloseable {
     private final short version;
     private @Nullable Socket socket;
 
+    protected record FromServerMessage(FromServerProto proto, long messageId) {}
+
     public Device(short version, String guid) {
         log = LoggerFactory.getLogger(getClass().getName() + "." + guid);
         this.guid = guid;
@@ -85,6 +87,10 @@ public abstract class Device implements AutoCloseable {
     }
 
     protected synchronized FromServerProto read() throws IOException {
+        return readWithMessageId().proto();
+    }
+
+    protected synchronized FromServerMessage readWithMessageId() throws IOException {
         requireConnection();
 
         var in = requireNonNull(socket).getInputStream();
@@ -143,7 +149,7 @@ public abstract class Device implements AutoCloseable {
                                     decode.getClass().getSimpleName(),
                                     decode));
         }
-        return fsp;
+        return new FromServerMessage(fsp, packet.rrId());
     }
 
     protected void requireConnection() {

--- a/src/main/java/pl/grzeslowski/openhab/supla/actions/SuplaServerActionsSupport.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/actions/SuplaServerActionsSupport.java
@@ -49,10 +49,6 @@ abstract class SuplaServerActionsSupport implements ThingActions {
         return localHandler;
     }
 
-    protected int nextSenderId(ServerSuplaDeviceHandler localHandler) {
-        return localHandler.getSenderId().getAndIncrement();
-    }
-
     protected String runAction(String actionName, Action action) {
         try {
             return action.run();

--- a/src/main/java/pl/grzeslowski/openhab/supla/actions/SuplaServerConfigModeActions.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/actions/SuplaServerConfigModeActions.java
@@ -6,6 +6,7 @@ import static pl.grzeslowski.jsupla.protocol.api.CalCfgResult.SUPLA_CALCFG_RESUL
 import static pl.grzeslowski.jsupla.protocol.api.DeviceFlag.SUPLA_DEVICE_FLAG_CALCFG_ENTER_CFG_MODE;
 import static pl.grzeslowski.openhab.supla.internal.Localization.text;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ACTION_SCOPE_CONFIG_MODE;
+import static pl.grzeslowski.openhab.supla.internal.server.handler.trait.ServerDevice.SENDER_ID;
 
 import java.util.concurrent.TimeoutException;
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -45,7 +46,7 @@ public class SuplaServerConfigModeActions extends SuplaServerActionsSupport {
         }
 
         var message = new DeviceCalCfgRequest(
-                nextSenderId(localHandler),
+                SENDER_ID,
                 NOT_BOUND_TO_CHANNEL,
                 SUPLA_CALCFG_CMD_ENTER_CFG_MODE.getValue(),
                 SUPER_USER_AUTHORIZED,

--- a/src/main/java/pl/grzeslowski/openhab/supla/actions/SuplaServerElectricityMeterActions.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/actions/SuplaServerElectricityMeterActions.java
@@ -5,6 +5,7 @@ import static pl.grzeslowski.jsupla.protocol.api.CalCfgCommand.SUPLA_CALCFG_CMD_
 import static pl.grzeslowski.jsupla.protocol.api.CalCfgResult.SUPLA_CALCFG_RESULT_DONE;
 import static pl.grzeslowski.openhab.supla.internal.Localization.text;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ACTION_SCOPE_ELECTRICITY_METER;
+import static pl.grzeslowski.openhab.supla.internal.server.handler.trait.ServerDevice.SENDER_ID;
 
 import java.util.concurrent.TimeoutException;
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -79,7 +80,7 @@ public class SuplaServerElectricityMeterActions extends SuplaServerActionsSuppor
         }
 
         var message = new DeviceCalCfgRequest(
-                nextSenderId(localHandler),
+                SENDER_ID,
                 channelNumber,
                 SUPLA_CALCFG_CMD_RESET_COUNTERS.getValue(),
                 SUPER_USER_AUTHORIZED,

--- a/src/main/java/pl/grzeslowski/openhab/supla/actions/SuplaServerFirmwareUpdateActions.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/actions/SuplaServerFirmwareUpdateActions.java
@@ -9,6 +9,7 @@ import static pl.grzeslowski.jsupla.protocol.api.CalCfgResult.SUPLA_CALCFG_RESUL
 import static pl.grzeslowski.jsupla.protocol.api.DeviceFlag.SUPLA_DEVICE_FLAG_AUTOMATIC_FIRMWARE_UPDATE_SUPPORTED;
 import static pl.grzeslowski.openhab.supla.internal.Localization.text;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ACTION_SCOPE_FIRMWARE_UPDATE;
+import static pl.grzeslowski.openhab.supla.internal.server.handler.trait.ServerDevice.SENDER_ID;
 
 import java.util.concurrent.TimeoutException;
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -40,7 +41,7 @@ public class SuplaServerFirmwareUpdateActions extends SuplaServerActionsSupport 
         }
 
         var message = new DeviceCalCfgRequest(
-                nextSenderId(localHandler),
+                SENDER_ID,
                 NOT_BOUND_TO_CHANNEL,
                 SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue(),
                 SUPER_USER_AUTHORIZED,
@@ -49,12 +50,14 @@ public class SuplaServerFirmwareUpdateActions extends SuplaServerActionsSupport 
                 EMPTY_DATA);
 
         localHandler.clearDeviceCalCfgResult();
-        localHandler.markOtaCheckPending(message.senderId());
         var timeout = localHandler.getConfiguration().getCheckFirmwareUpdateActionTimeout();
         var timeoutMillis = timeout.toMillis();
         var checkFirmwareUpdateStart = System.nanoTime();
+        long messageId;
         try {
             var future = writer.write(message);
+            messageId = future.msgId();
+            localHandler.markOtaCheckPending(messageId);
             future.await(timeoutMillis, MILLISECONDS);
             if (!future.isSuccess()) {
                 throw new RuntimeException("Check firmware update dispatch failed! request=%s, cause=%s"
@@ -72,7 +75,7 @@ public class SuplaServerFirmwareUpdateActions extends SuplaServerActionsSupport 
             localHandler.markOtaCheckError();
             throw e;
         }
-        if (result.receiverId() != message.senderId()) {
+        if (Integer.toUnsignedLong(result.receiverId()) != messageId) {
             localHandler.markOtaCheckError();
             throw new RuntimeException("Check firmware update returned a different receiver id! request=%s, result=%s"
                     .formatted(message, result));
@@ -168,7 +171,7 @@ public class SuplaServerFirmwareUpdateActions extends SuplaServerActionsSupport 
         }
 
         var message = new DeviceCalCfgRequest(
-                nextSenderId(localHandler),
+                SENDER_ID,
                 NOT_BOUND_TO_CHANNEL,
                 command.getValue(),
                 SUPER_USER_AUTHORIZED,

--- a/src/main/java/pl/grzeslowski/openhab/supla/actions/SuplaServerFirmwareUpdateActions.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/actions/SuplaServerFirmwareUpdateActions.java
@@ -50,6 +50,7 @@ public class SuplaServerFirmwareUpdateActions extends SuplaServerActionsSupport 
                 EMPTY_DATA);
 
         localHandler.clearDeviceCalCfgResult();
+        localHandler.markOtaCheckPending();
         var timeout = localHandler.getConfiguration().getCheckFirmwareUpdateActionTimeout();
         var timeoutMillis = timeout.toMillis();
         var checkFirmwareUpdateStart = System.nanoTime();
@@ -57,7 +58,7 @@ public class SuplaServerFirmwareUpdateActions extends SuplaServerActionsSupport 
         try {
             var future = writer.write(message);
             messageId = future.msgId();
-            localHandler.markOtaCheckPending(messageId);
+            localHandler.markOtaCheckMessageId(messageId);
             future.await(timeoutMillis, MILLISECONDS);
             if (!future.isSuccess()) {
                 throw new RuntimeException("Check firmware update dispatch failed! request=%s, cause=%s"

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/ChannelUtil.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/ChannelUtil.java
@@ -327,7 +327,7 @@ public class ChannelUtil {
 
     public void consumeSuplaChannelNewValueResult(SuplaChannelNewValueResult value) {
         var channelAndPreviousState =
-                invoker.getMessageIdToChannelUID().remove(Integer.toUnsignedLong(value.senderId()));
+                invoker.getChannelNumberToChannelUID().remove(Integer.valueOf(value.channelNumber()));
         if (value.success() != 0) {
             // operation was successful; can terminate
             return;

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/ChannelUtil.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/ChannelUtil.java
@@ -326,7 +326,8 @@ public class ChannelUtil {
     }
 
     public void consumeSuplaChannelNewValueResult(SuplaChannelNewValueResult value) {
-        var channelAndPreviousState = invoker.getSenderIdToChannelUID().remove(value.senderId());
+        var channelAndPreviousState =
+                invoker.getMessageIdToChannelUID().remove(Integer.toUnsignedLong(value.senderId()));
         if (value.success() != 0) {
             // operation was successful; can terminate
             return;

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/GatewayDeviceHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/GatewayDeviceHandler.java
@@ -12,7 +12,6 @@ import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.GATEWA
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.*;
 import static pl.grzeslowski.openhab.supla.internal.server.ChannelUtil.findId;
 
-import io.netty.channel.ChannelFuture;
 import java.util.*;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -34,6 +33,7 @@ import pl.grzeslowski.jsupla.protocol.api.structs.ds.SubdeviceDetails;
 import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaChannelNewValueResult;
 import pl.grzeslowski.jsupla.protocol.api.structs.dsc.ChannelState;
 import pl.grzeslowski.jsupla.protocol.api.types.FromServerProto;
+import pl.grzeslowski.jsupla.server.SuplaWriteFuture;
 import pl.grzeslowski.openhab.supla.internal.GuidLogger;
 import pl.grzeslowski.openhab.supla.internal.handler.OfflineInitializationException;
 import pl.grzeslowski.openhab.supla.internal.server.ChannelUtil;
@@ -346,13 +346,8 @@ public class GatewayDeviceHandler extends ServerSuplaDeviceHandler implements Se
     }
 
     @Override
-    public AtomicInteger getSenderId() {
-        throw new UnsupportedOperationException("ServerGatewayDeviceHandler.getSenderId()");
-    }
-
-    @Override
-    public Map<Integer, ChannelAndPreviousState> getSenderIdToChannelUID() {
-        throw new UnsupportedOperationException("ServerGatewayDeviceHandler.getSenderIdToChannelUID()");
+    public Map<Long, ChannelAndPreviousState> getMessageIdToChannelUID() {
+        throw new UnsupportedOperationException("ServerGatewayDeviceHandler.getMessageIdToChannelUID()");
     }
 
     @Override
@@ -361,7 +356,7 @@ public class GatewayDeviceHandler extends ServerSuplaDeviceHandler implements Se
     }
 
     @Override
-    public ChannelFuture write(FromServerProto proto) {
+    public SuplaWriteFuture write(FromServerProto proto) {
         throw new UnsupportedOperationException("ServerGatewayDeviceHandler.write(proto)");
     }
 

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/GatewayDeviceHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/GatewayDeviceHandler.java
@@ -346,8 +346,8 @@ public class GatewayDeviceHandler extends ServerSuplaDeviceHandler implements Se
     }
 
     @Override
-    public Map<Long, ChannelAndPreviousState> getMessageIdToChannelUID() {
-        throw new UnsupportedOperationException("ServerGatewayDeviceHandler.getMessageIdToChannelUID()");
+    public Map<Integer, ChannelAndPreviousState> getChannelNumberToChannelUID() {
+        throw new UnsupportedOperationException("ServerGatewayDeviceHandler.getChannelNumberToChannelUID()");
     }
 
     @Override

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandler.java
@@ -168,7 +168,7 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
 
     private final AtomicReference<@Nullable SetDeviceConfigResult> setDeviceConfigResult = new AtomicReference<>();
     private final AtomicReference<@Nullable DeviceCalCfgResult> deviceCalCfgResult = new AtomicReference<>();
-    private final AtomicReference<@Nullable Integer> pendingOtaCheckSenderId = new AtomicReference<>();
+    private final AtomicReference<@Nullable Long> pendingOtaCheckMessageId = new AtomicReference<>();
     private final AtomicReference<@Nullable OtaStatus> otaCheckResult = new AtomicReference<>();
     private final AtomicReference<@Nullable Future<?>> softwareUpdateCheckFuture = new AtomicReference<>();
     private final AtomicLong softwareUpdateCheckId = new AtomicLong();
@@ -694,15 +694,15 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
     }
 
     private boolean isCurrentOtaCheckResult(DeviceCalCfgResult value) {
-        var pendingSenderId = pendingOtaCheckSenderId.get();
-        if (pendingSenderId == null) {
+        var pendingMessageId = pendingOtaCheckMessageId.get();
+        if (pendingMessageId == null) {
             logger.debug("Ignoring firmware check result without a pending request. result={}", value);
             return false;
         }
-        if (value.receiverId() != pendingSenderId) {
+        if (Integer.toUnsignedLong(value.receiverId()) != pendingMessageId) {
             logger.debug(
-                    "Ignoring firmware check result for a different request. pendingSenderId={}, result={}",
-                    pendingSenderId,
+                    "Ignoring firmware check result for a different request. pendingMessageId={}, result={}",
+                    pendingMessageId,
                     value);
             return false;
         }
@@ -719,30 +719,30 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
                 .anyMatch(SUPLA_DEVICE_FLAG_AUTOMATIC_FIRMWARE_UPDATE_SUPPORTED::equals);
     }
 
-    public void markOtaCheckPending(int senderId) {
-        pendingOtaCheckSenderId.set(senderId);
+    public void markOtaCheckPending(long messageId) {
+        pendingOtaCheckMessageId.set(messageId);
         otaCheckResult.set(null);
         updateOtaState(OtaStatus.CHECKING, null, null, null);
     }
 
     public boolean isOtaCheckPending() {
-        return pendingOtaCheckSenderId.get() != null;
+        return pendingOtaCheckMessageId.get() != null;
     }
 
     public void markOtaUpdateTriggered() {
-        pendingOtaCheckSenderId.set(null);
+        pendingOtaCheckMessageId.set(null);
         updateOtaState(OtaStatus.UPDATE_TRIGGERED, null, null, now());
     }
 
     public void markOtaCheckError() {
         otaCheckResult.set(OtaStatus.ERROR);
-        pendingOtaCheckSenderId.set(null);
+        pendingOtaCheckMessageId.set(null);
         updateOtaState(OtaStatus.ERROR, null, null, now());
     }
 
     public void clearOtaState() {
         otaCheckResult.set(null);
-        pendingOtaCheckSenderId.set(null);
+        pendingOtaCheckMessageId.set(null);
         setProperty(OTA_STATUS_PROPERTY, null);
         setProperty(OTA_VERSION_AVAILABLE_PROPERTY, null);
         setProperty(OTA_CHANGELOG_URL_PROPERTY, null);
@@ -845,7 +845,7 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
             otaCheckResult.set(OtaStatus.ERROR);
             updateOtaState(OtaStatus.ERROR, null, null, now());
         } finally {
-            pendingOtaCheckSenderId.set(null);
+            pendingOtaCheckMessageId.set(null);
         }
     }
 

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandler.java
@@ -113,6 +113,7 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
         implements MessageHandler, ServerDevice, Ping.DeviceStatusUpdater {
     public static final byte ACTIVITY_TIMEOUT = (byte) 100;
     public static final String AVAILABLE_FIELDS = "AVAILABLE_FIELDS";
+    private static final long OTA_CHECK_PENDING_WITHOUT_MESSAGE_ID = -1L;
     private static final String SOFTWARE_UPDATE_THREAD_POOL_NAME = BINDING_ID + "-software-update";
     private static final AtomicLong ID = new AtomicLong();
     private static final Set<String> PRODUCT_INFO_PROPERTIES = Set.of(
@@ -169,6 +170,8 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
     private final AtomicReference<@Nullable SetDeviceConfigResult> setDeviceConfigResult = new AtomicReference<>();
     private final AtomicReference<@Nullable DeviceCalCfgResult> deviceCalCfgResult = new AtomicReference<>();
     private final AtomicReference<@Nullable Long> pendingOtaCheckMessageId = new AtomicReference<>();
+    private final Object otaCheckLock = new Object();
+    private final Queue<DeviceCalCfgResult> otaCheckResultsBeforeMessageId = new ArrayDeque<>();
     private final AtomicReference<@Nullable OtaStatus> otaCheckResult = new AtomicReference<>();
     private final AtomicReference<@Nullable Future<?>> softwareUpdateCheckFuture = new AtomicReference<>();
     private final AtomicLong softwareUpdateCheckId = new AtomicLong();
@@ -671,17 +674,29 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
 
     public void consumeDeviceCalCfgResult(DeviceCalCfgResult value) {
         if (value.command() == SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue()) {
-            if (!isCurrentOtaCheckResult(value)) {
-                return;
+            synchronized (otaCheckLock) {
+                if (isOtaCheckPendingWithoutMessageId()) {
+                    deferOtaCheckResult(value);
+                    return;
+                }
+                if (!isCurrentOtaCheckResult(value)) {
+                    return;
+                }
+                if (isAsyncFirmwareCheckResult(value)) {
+                    consumeFirmwareCheckResult(value);
+                    return;
+                }
+                if (value.result() != SUPLA_CALCFG_RESULT_DONE.getValue()) {
+                    markOtaCheckError();
+                }
+                storeDeviceCalCfgResult(value);
             }
-            if (isAsyncFirmwareCheckResult(value)) {
-                consumeFirmwareCheckResult(value);
-                return;
-            }
-            if (value.result() != SUPLA_CALCFG_RESULT_DONE.getValue()) {
-                markOtaCheckError();
-            }
+            return;
         }
+        storeDeviceCalCfgResult(value);
+    }
+
+    private void storeDeviceCalCfgResult(DeviceCalCfgResult value) {
         if (value.result() != SUPLA_CALCFG_RESULT_DONE.getValue()) {
             logger.warn("Did not succeed ({}) with device calcfg command. result={}", value.result(), value);
         } else {
@@ -690,6 +705,18 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
         var previous = deviceCalCfgResult.getAndSet(value);
         if (previous != null) {
             logger.warn("Previous deviceCalCfgResult was not null. Wierd thing might happen! previous={}", previous);
+        }
+    }
+
+    private boolean isOtaCheckPendingWithoutMessageId() {
+        var pendingMessageId = pendingOtaCheckMessageId.get();
+        return pendingMessageId != null && pendingMessageId == OTA_CHECK_PENDING_WITHOUT_MESSAGE_ID;
+    }
+
+    private void deferOtaCheckResult(DeviceCalCfgResult value) {
+        otaCheckResultsBeforeMessageId.add(value);
+        if (!isOtaCheckPendingWithoutMessageId()) {
+            consumeDeferredOtaCheckResults();
         }
     }
 
@@ -719,10 +746,35 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
                 .anyMatch(SUPLA_DEVICE_FLAG_AUTOMATIC_FIRMWARE_UPDATE_SUPPORTED::equals);
     }
 
+    public void markOtaCheckPending() {
+        synchronized (otaCheckLock) {
+            otaCheckResultsBeforeMessageId.clear();
+            pendingOtaCheckMessageId.set(OTA_CHECK_PENDING_WITHOUT_MESSAGE_ID);
+            otaCheckResult.set(null);
+            updateOtaState(OtaStatus.CHECKING, null, null, null);
+        }
+    }
+
+    public void markOtaCheckMessageId(long messageId) {
+        synchronized (otaCheckLock) {
+            pendingOtaCheckMessageId.set(messageId);
+            consumeDeferredOtaCheckResults();
+        }
+    }
+
     public void markOtaCheckPending(long messageId) {
-        pendingOtaCheckMessageId.set(messageId);
-        otaCheckResult.set(null);
-        updateOtaState(OtaStatus.CHECKING, null, null, null);
+        markOtaCheckPending();
+        markOtaCheckMessageId(messageId);
+    }
+
+    private void consumeDeferredOtaCheckResults() {
+        if (isOtaCheckPendingWithoutMessageId()) {
+            return;
+        }
+        DeviceCalCfgResult value;
+        while ((value = otaCheckResultsBeforeMessageId.poll()) != null) {
+            consumeDeviceCalCfgResult(value);
+        }
     }
 
     public boolean isOtaCheckPending() {
@@ -730,23 +782,32 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
     }
 
     public void markOtaUpdateTriggered() {
-        pendingOtaCheckMessageId.set(null);
-        updateOtaState(OtaStatus.UPDATE_TRIGGERED, null, null, now());
+        synchronized (otaCheckLock) {
+            pendingOtaCheckMessageId.set(null);
+            otaCheckResultsBeforeMessageId.clear();
+            updateOtaState(OtaStatus.UPDATE_TRIGGERED, null, null, now());
+        }
     }
 
     public void markOtaCheckError() {
-        otaCheckResult.set(OtaStatus.ERROR);
-        pendingOtaCheckMessageId.set(null);
-        updateOtaState(OtaStatus.ERROR, null, null, now());
+        synchronized (otaCheckLock) {
+            otaCheckResult.set(OtaStatus.ERROR);
+            pendingOtaCheckMessageId.set(null);
+            otaCheckResultsBeforeMessageId.clear();
+            updateOtaState(OtaStatus.ERROR, null, null, now());
+        }
     }
 
     public void clearOtaState() {
-        otaCheckResult.set(null);
-        pendingOtaCheckMessageId.set(null);
-        setProperty(OTA_STATUS_PROPERTY, null);
-        setProperty(OTA_VERSION_AVAILABLE_PROPERTY, null);
-        setProperty(OTA_CHANGELOG_URL_PROPERTY, null);
-        setProperty(OTA_LAST_CHECK_PROPERTY, null);
+        synchronized (otaCheckLock) {
+            otaCheckResult.set(null);
+            pendingOtaCheckMessageId.set(null);
+            otaCheckResultsBeforeMessageId.clear();
+            setProperty(OTA_STATUS_PROPERTY, null);
+            setProperty(OTA_VERSION_AVAILABLE_PROPERTY, null);
+            setProperty(OTA_CHANGELOG_URL_PROPERTY, null);
+            setProperty(OTA_LAST_CHECK_PROPERTY, null);
+        }
     }
 
     public synchronized SetDeviceConfigResult listenForSetDeviceConfigResult(long maxTime, TimeUnit timeUnit)
@@ -846,6 +907,7 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
             updateOtaState(OtaStatus.ERROR, null, null, now());
         } finally {
             pendingOtaCheckMessageId.set(null);
+            otaCheckResultsBeforeMessageId.clear();
         }
     }
 

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/SingleDeviceHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/SingleDeviceHandler.java
@@ -8,11 +8,9 @@ import static pl.grzeslowski.openhab.supla.internal.Documentation.THING_BRIDGE;
 import static pl.grzeslowski.openhab.supla.internal.Localization.text;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.SUPLA_GATEWAY_DEVICE_TYPE;
 
-import io.netty.channel.ChannelFuture;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Getter;
 import lombok.experimental.Delegate;
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -24,6 +22,7 @@ import pl.grzeslowski.jsupla.protocol.api.structs.ds.SubdeviceDetails;
 import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaChannelNewValueResult;
 import pl.grzeslowski.jsupla.protocol.api.structs.dsc.ChannelState;
 import pl.grzeslowski.jsupla.protocol.api.types.FromServerProto;
+import pl.grzeslowski.jsupla.server.SuplaWriteFuture;
 import pl.grzeslowski.openhab.supla.internal.handler.OfflineInitializationException;
 import pl.grzeslowski.openhab.supla.internal.server.ChannelUtil;
 import pl.grzeslowski.openhab.supla.internal.server.handler.trait.HandleCommand;
@@ -35,10 +34,7 @@ import pl.grzeslowski.openhab.supla.internal.server.traits.RegisterDeviceTrait;
 @NonNullByDefault
 public class SingleDeviceHandler extends ServerSuplaDeviceHandler {
     @Getter
-    private final AtomicInteger senderId = new AtomicInteger(1);
-
-    @Getter
-    private final Map<Integer, ChannelAndPreviousState> senderIdToChannelUID = synchronizedMap(new HashMap<>());
+    private final Map<Long, ChannelAndPreviousState> messageIdToChannelUID = synchronizedMap(new HashMap<>());
 
     private final ChannelUtil channelUtil = new ChannelUtil(this);
 
@@ -97,7 +93,7 @@ public class SingleDeviceHandler extends ServerSuplaDeviceHandler {
     }
 
     @Override
-    public ChannelFuture write(FromServerProto proto) {
+    public SuplaWriteFuture write(FromServerProto proto) {
         var writer = requireNonNull(getWriter().get(), "There is no writer!");
         logger.debug("Writing proto {}", proto);
         return writer.write(proto);

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/SingleDeviceHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/SingleDeviceHandler.java
@@ -34,7 +34,7 @@ import pl.grzeslowski.openhab.supla.internal.server.traits.RegisterDeviceTrait;
 @NonNullByDefault
 public class SingleDeviceHandler extends ServerSuplaDeviceHandler {
     @Getter
-    private final Map<Long, ChannelAndPreviousState> messageIdToChannelUID = synchronizedMap(new HashMap<>());
+    private final Map<Integer, ChannelAndPreviousState> channelNumberToChannelUID = synchronizedMap(new HashMap<>());
 
     private final ChannelUtil channelUtil = new ChannelUtil(this);
 

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/SubDeviceHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/SubDeviceHandler.java
@@ -7,12 +7,10 @@ import static org.openhab.core.thing.ThingStatus.ONLINE;
 import static org.openhab.core.thing.ThingStatusDetail.*;
 import static pl.grzeslowski.openhab.supla.internal.Localization.text;
 
-import io.netty.channel.ChannelFuture;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.Delegate;
@@ -26,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import pl.grzeslowski.jsupla.protocol.api.structs.dcs.SetCaption;
 import pl.grzeslowski.jsupla.protocol.api.structs.ds.*;
 import pl.grzeslowski.jsupla.protocol.api.types.FromServerProto;
+import pl.grzeslowski.jsupla.server.SuplaWriteFuture;
 import pl.grzeslowski.openhab.supla.internal.handler.SuplaDeviceHandler;
 import pl.grzeslowski.openhab.supla.internal.server.ChannelUtil;
 import pl.grzeslowski.openhab.supla.internal.server.cache.InMemoryStateCache;
@@ -61,10 +60,7 @@ public class SubDeviceHandler extends SuplaDeviceHandler implements ServerDevice
     private GatewayDeviceHandler bridgeHandler;
 
     @Getter
-    private final AtomicInteger senderId = new AtomicInteger(1);
-
-    @Getter
-    private final Map<Integer, ChannelAndPreviousState> senderIdToChannelUID = synchronizedMap(new HashMap<>());
+    private final Map<Long, ChannelAndPreviousState> messageIdToChannelUID = synchronizedMap(new HashMap<>());
 
     @Getter
     private List<DeviceChannel> channels = List.of();
@@ -197,7 +193,7 @@ public class SubDeviceHandler extends SuplaDeviceHandler implements ServerDevice
     }
 
     @Override
-    public ChannelFuture write(FromServerProto proto) {
+    public SuplaWriteFuture write(FromServerProto proto) {
         var local = requireNonNull(bridgeHandler, "There is not bridge!");
         var writer = requireNonNull(local.getWriter().get(), "There is not writer!");
         logger.debug("Writing proto {}", proto);

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/SubDeviceHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/SubDeviceHandler.java
@@ -60,7 +60,7 @@ public class SubDeviceHandler extends SuplaDeviceHandler implements ServerDevice
     private GatewayDeviceHandler bridgeHandler;
 
     @Getter
-    private final Map<Long, ChannelAndPreviousState> messageIdToChannelUID = synchronizedMap(new HashMap<>());
+    private final Map<Integer, ChannelAndPreviousState> channelNumberToChannelUID = synchronizedMap(new HashMap<>());
 
     @Getter
     private List<DeviceChannel> channels = List.of();

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/HandlerCommandTrait.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/HandlerCommandTrait.java
@@ -13,7 +13,6 @@ import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.Channe
 import static pl.grzeslowski.openhab.supla.internal.server.ChannelUtil.findSuplaChannelNumber;
 import static tech.units.indriya.unit.Units.CELSIUS;
 
-import io.netty.channel.ChannelFuture;
 import jakarta.annotation.Nullable;
 import java.math.BigDecimal;
 import java.util.Optional;
@@ -32,6 +31,7 @@ import pl.grzeslowski.jsupla.protocol.api.HvacMode;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.encoders.ChannelTypeEncoder;
 import pl.grzeslowski.jsupla.protocol.api.channeltype.value.*;
 import pl.grzeslowski.jsupla.protocol.api.structs.sd.SuplaChannelNewValue;
+import pl.grzeslowski.jsupla.server.SuplaWriteFuture;
 import pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ChannelIds.RgbwLed;
 
 @NonNullByDefault
@@ -250,11 +250,12 @@ public class HandlerCommandTrait implements HandleCommand {
     }
 
     @SuppressWarnings("UnusedReturnValue")
-    private ChannelFuture sendCommandToSuplaServer(ChannelUID channelUID, ChannelValue channelValue, Command command) {
+    private SuplaWriteFuture sendCommandToSuplaServer(
+            ChannelUID channelUID, ChannelValue channelValue, Command command) {
         return sendCommandToSuplaServer(channelUID, channelValue, command, null);
     }
 
-    private ChannelFuture sendCommandToSuplaServer(
+    private SuplaWriteFuture sendCommandToSuplaServer(
             ChannelUID channelUID, ChannelValue channelValue, Command command, @Nullable State previousState) {
         var maybeChannelNumber = findSuplaChannelNumber(channelUID);
         if (maybeChannelNumber.isEmpty()) {
@@ -263,13 +264,12 @@ public class HandlerCommandTrait implements HandleCommand {
         var channelNumber = maybeChannelNumber.get();
 
         var encode = ChannelTypeEncoder.INSTANCE.encode(channelValue);
-        var senderId = serverDevice.getSenderId().getAndIncrement();
-        serverDevice
-                .getSenderIdToChannelUID()
-                .put(senderId, new ServerDevice.ChannelAndPreviousState(channelUID, previousState));
-        var channelNewValue = new SuplaChannelNewValue(senderId, channelNumber, 100L, null, encode);
+        var channelNewValue = new SuplaChannelNewValue(ServerDevice.SENDER_ID, channelNumber, 100L, null, encode);
         try {
-            ChannelFuture future = serverDevice.write(channelNewValue);
+            var future = serverDevice.write(channelNewValue);
+            serverDevice
+                    .getMessageIdToChannelUID()
+                    .put(future.msgId(), new ServerDevice.ChannelAndPreviousState(channelUID, previousState));
             future.addListener(__ -> {
                 serverDevice.getLogger().debug("Changed value of channel for {} command {}", channelUID, command);
                 serverDevice.updateStatus(ONLINE);

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/HandlerCommandTrait.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/HandlerCommandTrait.java
@@ -268,8 +268,10 @@ public class HandlerCommandTrait implements HandleCommand {
         try {
             var future = serverDevice.write(channelNewValue);
             serverDevice
-                    .getMessageIdToChannelUID()
-                    .put(future.msgId(), new ServerDevice.ChannelAndPreviousState(channelUID, previousState));
+                    .getChannelNumberToChannelUID()
+                    .put(
+                            Integer.valueOf(channelNumber),
+                            new ServerDevice.ChannelAndPreviousState(channelUID, previousState));
             future.addListener(__ -> {
                 serverDevice.getLogger().debug("Changed value of channel for {} command {}", channelUID, command);
                 serverDevice.updateStatus(ONLINE);

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/ServerDevice.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/ServerDevice.java
@@ -29,7 +29,7 @@ public interface ServerDevice extends HandleCommand, StateCache {
     @Nullable
     ServerBridge getBridgeHandler();
 
-    Map<Long, ChannelAndPreviousState> getMessageIdToChannelUID();
+    Map<Integer, ChannelAndPreviousState> getChannelNumberToChannelUID();
 
     void updateState(ChannelUID uid, State state);
 

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/ServerDevice.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/ServerDevice.java
@@ -1,8 +1,6 @@
 package pl.grzeslowski.openhab.supla.internal.server.handler.trait;
 
-import io.netty.channel.ChannelFuture;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.thing.ChannelUID;
@@ -13,10 +11,13 @@ import org.openhab.core.thing.binding.builder.ThingBuilder;
 import org.openhab.core.types.State;
 import org.slf4j.Logger;
 import pl.grzeslowski.jsupla.protocol.api.types.FromServerProto;
+import pl.grzeslowski.jsupla.server.SuplaWriteFuture;
 import pl.grzeslowski.openhab.supla.internal.server.cache.StateCache;
 
 @NonNullByDefault
 public interface ServerDevice extends HandleCommand, StateCache {
+    static final int SENDER_ID = 0;
+
     Logger getLogger();
 
     Thing getThing();
@@ -28,9 +29,7 @@ public interface ServerDevice extends HandleCommand, StateCache {
     @Nullable
     ServerBridge getBridgeHandler();
 
-    AtomicInteger getSenderId();
-
-    Map<Integer, ChannelAndPreviousState> getSenderIdToChannelUID();
+    Map<Long, ChannelAndPreviousState> getMessageIdToChannelUID();
 
     void updateState(ChannelUID uid, State state);
 
@@ -38,7 +37,7 @@ public interface ServerDevice extends HandleCommand, StateCache {
 
     void updateStatus(ThingStatus thingStatus);
 
-    ChannelFuture write(FromServerProto proto);
+    SuplaWriteFuture write(FromServerProto proto);
 
     @Nullable
     String setProperty(String name, @Nullable String value);

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/ChannelUtilTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/ChannelUtilTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
+import static org.openhab.core.library.types.OnOffType.OFF;
 import static pl.grzeslowski.jsupla.protocol.api.ChannelType.EV_TYPE_ELECTRICITY_METER_MEASUREMENT_V1;
 import static pl.grzeslowski.jsupla.protocol.api.ChannelType.SUPLA_CHANNELTYPE_ACTIONTRIGGER;
 import static pl.grzeslowski.jsupla.protocol.api.ChannelType.SUPLA_CHANNELTYPE_ELECTRICITY_METER;
@@ -118,11 +119,11 @@ class ChannelUtilTest {
     }
 
     @Test
-    void shouldDropStoredMessageEntryOnSuccess() {
-        var map = new HashMap<Long, ServerDevice.ChannelAndPreviousState>();
+    void shouldDropStoredChannelNumberEntryOnSuccess() {
+        var map = new HashMap<Integer, ServerDevice.ChannelAndPreviousState>();
         var channelUID = new ChannelUID("supla:test:1:1");
-        map.put(5L, new ServerDevice.ChannelAndPreviousState(channelUID, null));
-        when(serverDevice.getMessageIdToChannelUID()).thenReturn(map);
+        map.put(0, new ServerDevice.ChannelAndPreviousState(channelUID, null));
+        when(serverDevice.getChannelNumberToChannelUID()).thenReturn(map);
         var newValueResult =
                 new pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaChannelNewValueResult((short) 0, 5, (byte) 1);
 
@@ -133,9 +134,25 @@ class ChannelUtilTest {
     }
 
     @Test
-    void shouldRefreshWhenMessageMissing() {
-        var map = new HashMap<Long, ServerDevice.ChannelAndPreviousState>();
-        when(serverDevice.getMessageIdToChannelUID()).thenReturn(map);
+    void shouldUseChannelNumberWhenNewValueResultFailed() {
+        var map = new HashMap<Integer, ServerDevice.ChannelAndPreviousState>();
+        var channelUID = new ChannelUID("supla:test:1:2");
+        map.put(2, new ServerDevice.ChannelAndPreviousState(channelUID, OFF));
+        when(serverDevice.getChannelNumberToChannelUID()).thenReturn(map);
+        var newValueResult =
+                new pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaChannelNewValueResult((short) 2, 8, (byte) 0);
+
+        channelUtil.consumeSuplaChannelNewValueResult(newValueResult);
+
+        assertThat(map).isEmpty();
+        verify(serverDevice).updateState(channelUID, OFF);
+        verify(serverDevice).handleRefreshCommand(channelUID);
+    }
+
+    @Test
+    void shouldRefreshWhenChannelNumberMissing() {
+        var map = new HashMap<Integer, ServerDevice.ChannelAndPreviousState>();
+        when(serverDevice.getChannelNumberToChannelUID()).thenReturn(map);
         var channelUID = new ChannelUID("supla:test:1:2");
         var channel = mock(Channel.class);
         when(channel.getUID()).thenReturn(channelUID);

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/ChannelUtilTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/ChannelUtilTest.java
@@ -118,11 +118,11 @@ class ChannelUtilTest {
     }
 
     @Test
-    void shouldDropStoredSenderEntryOnSuccess() {
-        var map = new HashMap<Integer, ServerDevice.ChannelAndPreviousState>();
+    void shouldDropStoredMessageEntryOnSuccess() {
+        var map = new HashMap<Long, ServerDevice.ChannelAndPreviousState>();
         var channelUID = new ChannelUID("supla:test:1:1");
-        map.put(5, new ServerDevice.ChannelAndPreviousState(channelUID, null));
-        when(serverDevice.getSenderIdToChannelUID()).thenReturn(map);
+        map.put(5L, new ServerDevice.ChannelAndPreviousState(channelUID, null));
+        when(serverDevice.getMessageIdToChannelUID()).thenReturn(map);
         var newValueResult =
                 new pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaChannelNewValueResult((short) 0, 5, (byte) 1);
 
@@ -133,9 +133,9 @@ class ChannelUtilTest {
     }
 
     @Test
-    void shouldRefreshWhenSenderMissing() {
-        var map = new HashMap<Integer, ServerDevice.ChannelAndPreviousState>();
-        when(serverDevice.getSenderIdToChannelUID()).thenReturn(map);
+    void shouldRefreshWhenMessageMissing() {
+        var map = new HashMap<Long, ServerDevice.ChannelAndPreviousState>();
+        when(serverDevice.getMessageIdToChannelUID()).thenReturn(map);
         var channelUID = new ChannelUID("supla:test:1:2");
         var channel = mock(Channel.class);
         when(channel.getUID()).thenReturn(channelUID);

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/SuplaServerActionsTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/SuplaServerActionsTest.java
@@ -5,7 +5,6 @@ import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.openhab.core.thing.ThingStatus.OFFLINE;

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/SuplaServerActionsTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/SuplaServerActionsTest.java
@@ -20,13 +20,13 @@ import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ACTION
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ACTION_SCOPE_DEVICE_CONFIG;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ACTION_SCOPE_ELECTRICITY_METER;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ACTION_SCOPE_FIRMWARE_UPDATE;
+import static pl.grzeslowski.openhab.supla.internal.server.handler.trait.ServerDevice.SENDER_ID;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,7 +51,7 @@ import pl.grzeslowski.openhab.supla.internal.server.traits.SuplaDevice;
 
 @ExtendWith(MockitoExtension.class)
 class SuplaServerActionsTest {
-    private static final int ACTION_SENDER_ID = 37;
+    private static final int ACTION_MESSAGE_ID = 37;
 
     @Mock
     private ServerSuplaDeviceHandler handler;
@@ -62,17 +62,16 @@ class SuplaServerActionsTest {
     @Mock
     private Thing thing;
 
-    @Mock
-    private SuplaWriteFuture successfulFuture;
-
     private SuplaServerElectricityMeterActions electricityMeterActions;
     private SuplaServerConfigModeActions configModeActions;
     private SuplaServerFirmwareUpdateActions firmwareUpdateActions;
 
     private ServerDeviceHandlerConfiguration configuration;
+    private SuplaWriteFuture successfulFuture;
 
     @BeforeEach
     void setUp() {
+        successfulFuture = writeFuture(ACTION_MESSAGE_ID, true, null);
         configuration = new ServerDeviceHandlerConfiguration();
         electricityMeterActions = new SuplaServerElectricityMeterActions();
         configModeActions = new SuplaServerConfigModeActions();
@@ -82,7 +81,6 @@ class SuplaServerActionsTest {
         configModeActions.setThingHandler(handler);
         firmwareUpdateActions.setThingHandler(handler);
         org.mockito.Mockito.lenient().when(handler.getWriter()).thenReturn(new AtomicReference<>(writer));
-        org.mockito.Mockito.lenient().when(handler.getSenderId()).thenReturn(new AtomicInteger(ACTION_SENDER_ID));
         org.mockito.Mockito.lenient().when(handler.getThing()).thenReturn(thing);
         org.mockito.Mockito.lenient().when(handler.getConfiguration()).thenReturn(configuration);
         org.mockito.Mockito.lenient().when(thing.getUID()).thenReturn(new ThingUID("supla:test:1"));
@@ -164,7 +162,7 @@ class SuplaServerActionsTest {
         inOrder.verify(handler).clearDeviceCalCfgResult();
         inOrder.verify(writer)
                 .write(argThat(proto -> proto instanceof DeviceCalCfgRequest request
-                        && request.senderId() == ACTION_SENDER_ID
+                        && request.senderId() == SENDER_ID
                         && request.channelNumber() == 7
                         && request.command() == SUPLA_CALCFG_CMD_RESET_COUNTERS.getValue()
                         && request.superUserAuthorized() == 1
@@ -251,7 +249,7 @@ class SuplaServerActionsTest {
         inOrder.verify(handler).clearDeviceCalCfgResult();
         inOrder.verify(writer)
                 .write(argThat(proto -> proto instanceof DeviceCalCfgRequest request
-                        && request.senderId() == ACTION_SENDER_ID
+                        && request.senderId() == SENDER_ID
                         && request.channelNumber() == -1
                         && request.command() == SUPLA_CALCFG_CMD_ENTER_CFG_MODE.getValue()
                         && request.superUserAuthorized() == 1
@@ -312,7 +310,7 @@ class SuplaServerActionsTest {
     void shouldSendCheckFirmwareUpdateRequest() throws Exception {
         when(handler.listenForDeviceCalCfgResult(30_000, MILLISECONDS))
                 .thenReturn(new DeviceCalCfgResult(
-                        ACTION_SENDER_ID,
+                        ACTION_MESSAGE_ID,
                         -1,
                         SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue(),
                         SUPLA_CALCFG_RESULT_DONE.getValue(),
@@ -328,12 +326,12 @@ class SuplaServerActionsTest {
 
         var inOrder = inOrder(handler, writer);
         inOrder.verify(handler).clearDeviceCalCfgResult();
-        inOrder.verify(handler).markOtaCheckPending(ACTION_SENDER_ID);
         inOrder.verify(writer)
                 .write(argThat(proto -> proto instanceof DeviceCalCfgRequest request
-                        && request.senderId() == ACTION_SENDER_ID
+                        && request.senderId() == SENDER_ID
                         && request.channelNumber() == -1
                         && request.command() == SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue()));
+        inOrder.verify(handler).markOtaCheckPending(ACTION_MESSAGE_ID);
         inOrder.verify(handler).listenForDeviceCalCfgResult(30_000, MILLISECONDS);
         inOrder.verify(handler)
                 .listenForOtaCheckResult(
@@ -345,7 +343,7 @@ class SuplaServerActionsTest {
     void shouldFailWhenCheckFirmwareUpdateAcceptanceBelongsToDifferentRequest() throws Exception {
         when(handler.listenForDeviceCalCfgResult(30_000, MILLISECONDS))
                 .thenReturn(new DeviceCalCfgResult(
-                        ACTION_SENDER_ID - 1,
+                        ACTION_MESSAGE_ID - 1,
                         -1,
                         SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue(),
                         SUPLA_CALCFG_RESULT_DONE.getValue(),
@@ -362,7 +360,7 @@ class SuplaServerActionsTest {
         when(handler.listenForDeviceCalCfgResult(100, MILLISECONDS)).thenAnswer(invocation -> {
             Thread.sleep(40);
             return new DeviceCalCfgResult(
-                    ACTION_SENDER_ID,
+                    ACTION_MESSAGE_ID,
                     -1,
                     SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue(),
                     SUPLA_CALCFG_RESULT_DONE.getValue(),
@@ -388,7 +386,7 @@ class SuplaServerActionsTest {
         configuration.setCheckFirmwareUpdateActionTimeout("PT0S");
         when(handler.listenForDeviceCalCfgResult(0, MILLISECONDS))
                 .thenReturn(new DeviceCalCfgResult(
-                        ACTION_SENDER_ID,
+                        ACTION_MESSAGE_ID,
                         -1,
                         SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue(),
                         SUPLA_CALCFG_RESULT_DONE.getValue(),
@@ -407,7 +405,7 @@ class SuplaServerActionsTest {
 
         assertThat(firmwareUpdateActions.checkFirmwareUpdate()).contains("dispatch failed");
         verify(handler).clearDeviceCalCfgResult();
-        verify(handler).markOtaCheckPending(ACTION_SENDER_ID);
+        verify(handler, org.mockito.Mockito.never()).markOtaCheckPending(org.mockito.ArgumentMatchers.anyLong());
         verify(handler).markOtaCheckError();
     }
 
@@ -423,7 +421,7 @@ class SuplaServerActionsTest {
     void shouldMarkOtaCheckErrorWhenOtaCheckWaitTimesOut() throws Exception {
         when(handler.listenForDeviceCalCfgResult(30_000, MILLISECONDS))
                 .thenReturn(new DeviceCalCfgResult(
-                        ACTION_SENDER_ID,
+                        ACTION_MESSAGE_ID,
                         -1,
                         SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue(),
                         SUPLA_CALCFG_RESULT_DONE.getValue(),
@@ -440,15 +438,12 @@ class SuplaServerActionsTest {
 
     @Test
     void shouldFailWhenCheckFirmwareUpdateDispatchFutureIsFailed() {
-        var dispatchFailure = new IllegalStateException("write failed");
-        var failedFuture = mock(SuplaWriteFuture.class);
-        when(failedFuture.isSuccess()).thenReturn(false);
-        when(failedFuture.cause()).thenReturn(dispatchFailure);
+        var failedFuture = writeFuture(ACTION_MESSAGE_ID, false, new IllegalStateException("write failed"));
         when(writer.write(argThat(proto -> proto instanceof DeviceCalCfgRequest)))
                 .thenReturn(failedFuture);
 
         assertThat(firmwareUpdateActions.checkFirmwareUpdate()).contains("dispatch failed");
-        verify(handler).markOtaCheckPending(ACTION_SENDER_ID);
+        verify(handler).markOtaCheckPending(ACTION_MESSAGE_ID);
         verify(handler).markOtaCheckError();
     }
 
@@ -470,7 +465,7 @@ class SuplaServerActionsTest {
         inOrder.verify(handler).clearDeviceCalCfgResult();
         inOrder.verify(writer)
                 .write(argThat(proto -> proto instanceof DeviceCalCfgRequest request
-                        && request.senderId() == ACTION_SENDER_ID
+                        && request.senderId() == SENDER_ID
                         && request.channelNumber() == -1
                         && request.command() == SUPLA_CALCFG_CMD_START_FIRMWARE_UPDATE.getValue()));
         inOrder.verify(handler).markOtaUpdateTriggered();
@@ -492,7 +487,7 @@ class SuplaServerActionsTest {
 
         verify(writer)
                 .write(argThat(proto -> proto instanceof DeviceCalCfgRequest request
-                        && request.senderId() == ACTION_SENDER_ID
+                        && request.senderId() == SENDER_ID
                         && request.channelNumber() == -1
                         && request.command() == SUPLA_CALCFG_CMD_START_SECURITY_UPDATE.getValue()));
         verify(handler).markOtaUpdateTriggered();
@@ -516,6 +511,21 @@ class SuplaServerActionsTest {
                 .map(actionService ->
                         actionService.getAnnotation(ThingActionsScope.class).name())
                 .toList();
+    }
+
+    private static SuplaWriteFuture writeFuture(long messageId, boolean success, Throwable cause) {
+        var future = org.mockito.Mockito.mock(SuplaWriteFuture.class);
+        org.mockito.Mockito.lenient().when(future.msgId()).thenReturn(messageId);
+        org.mockito.Mockito.lenient().when(future.isSuccess()).thenReturn(success);
+        org.mockito.Mockito.lenient().when(future.cause()).thenReturn(cause);
+        try {
+            org.mockito.Mockito.lenient()
+                    .when(future.await(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.any()))
+                    .thenReturn(true);
+        } catch (InterruptedException e) {
+            throw new AssertionError(e);
+        }
+        return future;
     }
 
     private static List<Method> ruleActionMethods(Class<?> actionService) {

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/SuplaServerActionsTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/SuplaServerActionsTest.java
@@ -326,12 +326,13 @@ class SuplaServerActionsTest {
 
         var inOrder = inOrder(handler, writer);
         inOrder.verify(handler).clearDeviceCalCfgResult();
+        inOrder.verify(handler).markOtaCheckPending();
         inOrder.verify(writer)
                 .write(argThat(proto -> proto instanceof DeviceCalCfgRequest request
                         && request.senderId() == SENDER_ID
                         && request.channelNumber() == -1
                         && request.command() == SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue()));
-        inOrder.verify(handler).markOtaCheckPending(ACTION_MESSAGE_ID);
+        inOrder.verify(handler).markOtaCheckMessageId(ACTION_MESSAGE_ID);
         inOrder.verify(handler).listenForDeviceCalCfgResult(30_000, MILLISECONDS);
         inOrder.verify(handler)
                 .listenForOtaCheckResult(
@@ -405,7 +406,8 @@ class SuplaServerActionsTest {
 
         assertThat(firmwareUpdateActions.checkFirmwareUpdate()).contains("dispatch failed");
         verify(handler).clearDeviceCalCfgResult();
-        verify(handler, org.mockito.Mockito.never()).markOtaCheckPending(org.mockito.ArgumentMatchers.anyLong());
+        verify(handler).markOtaCheckPending();
+        verify(handler, org.mockito.Mockito.never()).markOtaCheckMessageId(org.mockito.ArgumentMatchers.anyLong());
         verify(handler).markOtaCheckError();
     }
 
@@ -443,7 +445,8 @@ class SuplaServerActionsTest {
                 .thenReturn(failedFuture);
 
         assertThat(firmwareUpdateActions.checkFirmwareUpdate()).contains("dispatch failed");
-        verify(handler).markOtaCheckPending(ACTION_MESSAGE_ID);
+        verify(handler).markOtaCheckPending();
+        verify(handler).markOtaCheckMessageId(ACTION_MESSAGE_ID);
         verify(handler).markOtaCheckError();
     }
 

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandlerTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandlerTest.java
@@ -59,7 +59,7 @@ import pl.grzeslowski.openhab.supla.internal.server.traits.RegisterEmailDeviceTr
 import pl.grzeslowski.openhab.supla.internal.updates.SuplaUpdatesClient;
 
 class ServerSuplaDeviceHandlerTest {
-    private static final int FIRMWARE_CHECK_SENDER_ID = 37;
+    private static final int FIRMWARE_CHECK_MESSAGE_ID = 37;
 
     private final Thing thing = Mockito.mock(Thing.class);
     private final Map<String, String> properties = new HashMap<>();
@@ -288,9 +288,9 @@ class ServerSuplaDeviceHandlerTest {
 
     @Test
     void shouldTreatImmediateFirmwareCheckAcceptanceAsSeparateResult() throws Exception {
-        handler.markOtaCheckPending(FIRMWARE_CHECK_SENDER_ID);
+        handler.markOtaCheckPending(FIRMWARE_CHECK_MESSAGE_ID);
         var immediateResult = new DeviceCalCfgResult(
-                FIRMWARE_CHECK_SENDER_ID,
+                FIRMWARE_CHECK_MESSAGE_ID,
                 -1,
                 SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue(),
                 SUPLA_CALCFG_RESULT_DONE.getValue(),
@@ -306,10 +306,10 @@ class ServerSuplaDeviceHandlerTest {
 
     @Test
     void shouldPersistAvailableFirmwareCheckResult() {
-        handler.markOtaCheckPending(FIRMWARE_CHECK_SENDER_ID);
+        handler.markOtaCheckPending(FIRMWARE_CHECK_MESSAGE_ID);
 
         handler.consumeDeviceCalCfgResult(new DeviceCalCfgResult(
-                FIRMWARE_CHECK_SENDER_ID,
+                FIRMWARE_CHECK_MESSAGE_ID,
                 -1,
                 SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue(),
                 SUPLA_CALCFG_RESULT_DONE.getValue(),
@@ -328,10 +328,10 @@ class ServerSuplaDeviceHandlerTest {
 
     @Test
     void shouldPersistNotAvailableFirmwareCheckResult() {
-        handler.markOtaCheckPending(FIRMWARE_CHECK_SENDER_ID);
+        handler.markOtaCheckPending(FIRMWARE_CHECK_MESSAGE_ID);
 
         handler.consumeDeviceCalCfgResult(new DeviceCalCfgResult(
-                FIRMWARE_CHECK_SENDER_ID,
+                FIRMWARE_CHECK_MESSAGE_ID,
                 -1,
                 SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue(),
                 SUPLA_CALCFG_RESULT_DONE.getValue(),
@@ -347,10 +347,10 @@ class ServerSuplaDeviceHandlerTest {
 
     @Test
     void shouldPersistErrorFirmwareCheckResult() {
-        handler.markOtaCheckPending(FIRMWARE_CHECK_SENDER_ID);
+        handler.markOtaCheckPending(FIRMWARE_CHECK_MESSAGE_ID);
 
         handler.consumeDeviceCalCfgResult(new DeviceCalCfgResult(
-                FIRMWARE_CHECK_SENDER_ID,
+                FIRMWARE_CHECK_MESSAGE_ID,
                 -1,
                 SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue(),
                 SUPLA_CALCFG_RESULT_DONE.getValue(),
@@ -363,10 +363,10 @@ class ServerSuplaDeviceHandlerTest {
 
     @Test
     void shouldPersistErrorWhenFirmwareCheckCommandIsRejected() {
-        handler.markOtaCheckPending(FIRMWARE_CHECK_SENDER_ID);
+        handler.markOtaCheckPending(FIRMWARE_CHECK_MESSAGE_ID);
 
         handler.consumeDeviceCalCfgResult(new DeviceCalCfgResult(
-                FIRMWARE_CHECK_SENDER_ID,
+                FIRMWARE_CHECK_MESSAGE_ID,
                 -1,
                 SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue(),
                 SUPLA_CALCFG_RESULT_NOT_SUPPORTED.getValue(),
@@ -379,10 +379,10 @@ class ServerSuplaDeviceHandlerTest {
 
     @Test
     void shouldIgnoreFirmwareCheckResultFromPreviousRequest() {
-        handler.markOtaCheckPending(FIRMWARE_CHECK_SENDER_ID);
+        handler.markOtaCheckPending(FIRMWARE_CHECK_MESSAGE_ID);
 
         handler.consumeDeviceCalCfgResult(new DeviceCalCfgResult(
-                FIRMWARE_CHECK_SENDER_ID - 1,
+                FIRMWARE_CHECK_MESSAGE_ID - 1,
                 -1,
                 SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue(),
                 SUPLA_CALCFG_RESULT_DONE.getValue(),
@@ -400,7 +400,7 @@ class ServerSuplaDeviceHandlerTest {
         assertThat(handler.isOtaCheckPending()).isTrue();
 
         handler.consumeDeviceCalCfgResult(new DeviceCalCfgResult(
-                FIRMWARE_CHECK_SENDER_ID,
+                FIRMWARE_CHECK_MESSAGE_ID,
                 -1,
                 SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue(),
                 SUPLA_CALCFG_RESULT_DONE.getValue(),

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandlerTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandlerTest.java
@@ -378,6 +378,49 @@ class ServerSuplaDeviceHandlerTest {
     }
 
     @Test
+    void shouldDeferFirmwareCheckResultUntilMessageIdIsKnown() throws Exception {
+        handler.markOtaCheckPending();
+        var immediateResult = new DeviceCalCfgResult(
+                FIRMWARE_CHECK_MESSAGE_ID,
+                -1,
+                SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue(),
+                SUPLA_CALCFG_RESULT_DONE.getValue(),
+                0L,
+                new byte[0]);
+
+        handler.consumeDeviceCalCfgResult(immediateResult);
+        handler.markOtaCheckMessageId(FIRMWARE_CHECK_MESSAGE_ID);
+
+        assertThat(handler.listenForDeviceCalCfgResult(1, SECONDS)).isEqualTo(immediateResult);
+        assertThat(properties.get(OTA_STATUS_PROPERTY)).isEqualTo("CHECKING");
+        assertThat(handler.isOtaCheckPending()).isTrue();
+    }
+
+    @Test
+    void shouldIgnoreDeferredFirmwareCheckResultFromPreviousRequest() {
+        handler.markOtaCheckPending();
+
+        handler.consumeDeviceCalCfgResult(new DeviceCalCfgResult(
+                FIRMWARE_CHECK_MESSAGE_ID - 1,
+                -1,
+                SUPLA_CALCFG_CMD_CHECK_FIRMWARE_UPDATE.getValue(),
+                SUPLA_CALCFG_RESULT_DONE.getValue(),
+                FirmwareCheckResult.SIZE,
+                encodeFirmwareCheckResult(
+                        SUPLA_FIRMWARE_CHECK_RESULT_UPDATE_AVAILABLE.getValue(),
+                        "9.9.9",
+                        "https://example.test/stale")));
+        handler.markOtaCheckMessageId(FIRMWARE_CHECK_MESSAGE_ID);
+
+        assertThat(properties.get(OTA_STATUS_PROPERTY)).isEqualTo("CHECKING");
+        assertThat(properties)
+                .doesNotContainKey(OTA_VERSION_AVAILABLE_PROPERTY)
+                .doesNotContainKey(OTA_CHANGELOG_URL_PROPERTY)
+                .doesNotContainKey(OTA_LAST_CHECK_PROPERTY);
+        assertThat(handler.isOtaCheckPending()).isTrue();
+    }
+
+    @Test
     void shouldIgnoreFirmwareCheckResultFromPreviousRequest() {
         handler.markOtaCheckPending(FIRMWARE_CHECK_MESSAGE_ID);
 

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/TestServerSuplaDeviceHandler.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/TestServerSuplaDeviceHandler.java
@@ -28,7 +28,7 @@ import pl.grzeslowski.openhab.supla.internal.server.traits.DeviceChannelValue;
 import pl.grzeslowski.openhab.supla.internal.server.traits.RegisterDeviceTrait;
 
 final class TestServerSuplaDeviceHandler extends ServerSuplaDeviceHandler {
-    private final Map<Long, ServerDevice.ChannelAndPreviousState> messageIdToChannelUID =
+    private final Map<Integer, ServerDevice.ChannelAndPreviousState> channelNumberToChannelUID =
             Collections.synchronizedMap(new HashMap<>());
 
     TestServerSuplaDeviceHandler(Thing thing) {
@@ -94,8 +94,8 @@ final class TestServerSuplaDeviceHandler extends ServerSuplaDeviceHandler {
     }
 
     @Override
-    public Map<Long, ChannelAndPreviousState> getMessageIdToChannelUID() {
-        return messageIdToChannelUID;
+    public Map<Integer, ChannelAndPreviousState> getChannelNumberToChannelUID() {
+        return channelNumberToChannelUID;
     }
 
     @Override

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/TestServerSuplaDeviceHandler.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/TestServerSuplaDeviceHandler.java
@@ -1,11 +1,9 @@
 package pl.grzeslowski.openhab.supla.internal.server.handler;
 
-import io.netty.channel.ChannelFuture;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.openhab.core.library.types.HSBType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
@@ -22,6 +20,7 @@ import pl.grzeslowski.jsupla.protocol.api.structs.ds.SubdeviceDetails;
 import pl.grzeslowski.jsupla.protocol.api.structs.ds.SuplaChannelNewValueResult;
 import pl.grzeslowski.jsupla.protocol.api.structs.dsc.ChannelState;
 import pl.grzeslowski.jsupla.protocol.api.types.FromServerProto;
+import pl.grzeslowski.jsupla.server.SuplaWriteFuture;
 import pl.grzeslowski.openhab.supla.internal.handler.InitializationException;
 import pl.grzeslowski.openhab.supla.internal.server.handler.trait.ServerBridge;
 import pl.grzeslowski.openhab.supla.internal.server.handler.trait.ServerDevice;
@@ -29,8 +28,7 @@ import pl.grzeslowski.openhab.supla.internal.server.traits.DeviceChannelValue;
 import pl.grzeslowski.openhab.supla.internal.server.traits.RegisterDeviceTrait;
 
 final class TestServerSuplaDeviceHandler extends ServerSuplaDeviceHandler {
-    private final AtomicInteger senderId = new AtomicInteger(1);
-    private final Map<Integer, ServerDevice.ChannelAndPreviousState> senderIdToChannelUID =
+    private final Map<Long, ServerDevice.ChannelAndPreviousState> messageIdToChannelUID =
             Collections.synchronizedMap(new HashMap<>());
 
     TestServerSuplaDeviceHandler(Thing thing) {
@@ -96,17 +94,12 @@ final class TestServerSuplaDeviceHandler extends ServerSuplaDeviceHandler {
     }
 
     @Override
-    public AtomicInteger getSenderId() {
-        return senderId;
+    public Map<Long, ChannelAndPreviousState> getMessageIdToChannelUID() {
+        return messageIdToChannelUID;
     }
 
     @Override
-    public Map<Integer, ChannelAndPreviousState> getSenderIdToChannelUID() {
-        return senderIdToChannelUID;
-    }
-
-    @Override
-    public ChannelFuture write(FromServerProto proto) {
+    public SuplaWriteFuture write(FromServerProto proto) {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/HandlerCommandTraitTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/HandlerCommandTraitTest.java
@@ -3,17 +3,15 @@ package pl.grzeslowski.openhab.supla.internal.server.handler.trait;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 import static org.openhab.core.library.types.OnOffType.OFF;
 import static org.openhab.core.library.types.OnOffType.ON;
 import static org.openhab.core.thing.ThingStatus.ONLINE;
 
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.DefaultChannelPromise;
-import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.concurrent.GenericFutureListener;
 import java.util.HashMap;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,9 +22,13 @@ import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.types.State;
 import org.slf4j.Logger;
+import pl.grzeslowski.jsupla.protocol.api.structs.sd.SuplaChannelNewValue;
+import pl.grzeslowski.jsupla.server.SuplaWriteFuture;
 
 @ExtendWith(MockitoExtension.class)
 class HandlerCommandTraitTest {
+    private static final long MESSAGE_ID = 13L;
+
     @Mock
     private ServerDevice serverDevice;
 
@@ -36,20 +38,16 @@ class HandlerCommandTraitTest {
     @InjectMocks
     private HandlerCommandTrait handlerCommandTrait;
 
-    private AtomicInteger senderId;
-    private HashMap<Integer, ServerDevice.ChannelAndPreviousState> senderMap;
-    private ChannelFuture successfulFuture;
+    private HashMap<Long, ServerDevice.ChannelAndPreviousState> messageMap;
+    private SuplaWriteFuture successfulFuture;
 
     @BeforeEach
     void setUp() {
-        senderId = new AtomicInteger();
-        senderMap = new HashMap<>();
-        var channel = new EmbeddedChannel();
-        successfulFuture = new DefaultChannelPromise(channel).setSuccess(null);
+        messageMap = new HashMap<>();
+        successfulFuture = successfulWriteFuture(MESSAGE_ID);
 
         lenient().when(serverDevice.getLogger()).thenReturn(logger);
-        lenient().when(serverDevice.getSenderId()).thenReturn(senderId);
-        lenient().when(serverDevice.getSenderIdToChannelUID()).thenReturn(senderMap);
+        lenient().when(serverDevice.getMessageIdToChannelUID()).thenReturn(messageMap);
         lenient().when(serverDevice.write(any())).thenReturn(successfulFuture);
     }
 
@@ -95,13 +93,15 @@ class HandlerCommandTraitTest {
 
         handlerCommandTrait.handleOnOffCommand(channelUID, ON);
 
-        assertThat(senderMap).hasSize(1);
-        var entry = senderMap.entrySet().iterator().next();
-        assertThat(entry.getKey()).isZero();
+        assertThat(messageMap).hasSize(1);
+        var entry = messageMap.entrySet().iterator().next();
+        assertThat(entry.getKey()).isEqualTo(MESSAGE_ID);
         ServerDevice.ChannelAndPreviousState value = entry.getValue();
         assertThat(value.channelUID()).isEqualTo(channelUID);
         assertThat((OnOffType) value.previousState()).isEqualTo(OFF);
-        verify(serverDevice).write(any());
+        verify(serverDevice)
+                .write(argThat(proto -> proto instanceof SuplaChannelNewValue newValue
+                        && newValue.senderId() == ServerDevice.SENDER_ID));
         verify(serverDevice).updateStatus(ONLINE);
     }
 
@@ -112,5 +112,17 @@ class HandlerCommandTraitTest {
         assertThatThrownBy(() -> handlerCommandTrait.handleOnOffCommand(channelUID, ON))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Cannot find channel number from");
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static SuplaWriteFuture successfulWriteFuture(long messageId) {
+        var future = mock(SuplaWriteFuture.class);
+        lenient().when(future.msgId()).thenReturn(messageId);
+        lenient().when(future.addListener(any())).thenAnswer(invocation -> {
+            var listener = (GenericFutureListener) invocation.getArgument(0);
+            listener.operationComplete(future);
+            return future;
+        });
+        return future;
     }
 }

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/HandlerCommandTraitTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/trait/HandlerCommandTraitTest.java
@@ -27,8 +27,6 @@ import pl.grzeslowski.jsupla.server.SuplaWriteFuture;
 
 @ExtendWith(MockitoExtension.class)
 class HandlerCommandTraitTest {
-    private static final long MESSAGE_ID = 13L;
-
     @Mock
     private ServerDevice serverDevice;
 
@@ -38,16 +36,16 @@ class HandlerCommandTraitTest {
     @InjectMocks
     private HandlerCommandTrait handlerCommandTrait;
 
-    private HashMap<Long, ServerDevice.ChannelAndPreviousState> messageMap;
+    private HashMap<Integer, ServerDevice.ChannelAndPreviousState> channelNumberMap;
     private SuplaWriteFuture successfulFuture;
 
     @BeforeEach
     void setUp() {
-        messageMap = new HashMap<>();
-        successfulFuture = successfulWriteFuture(MESSAGE_ID);
+        channelNumberMap = new HashMap<>();
+        successfulFuture = successfulWriteFuture();
 
         lenient().when(serverDevice.getLogger()).thenReturn(logger);
-        lenient().when(serverDevice.getMessageIdToChannelUID()).thenReturn(messageMap);
+        lenient().when(serverDevice.getChannelNumberToChannelUID()).thenReturn(channelNumberMap);
         lenient().when(serverDevice.write(any())).thenReturn(successfulFuture);
     }
 
@@ -93,9 +91,9 @@ class HandlerCommandTraitTest {
 
         handlerCommandTrait.handleOnOffCommand(channelUID, ON);
 
-        assertThat(messageMap).hasSize(1);
-        var entry = messageMap.entrySet().iterator().next();
-        assertThat(entry.getKey()).isEqualTo(MESSAGE_ID);
+        assertThat(channelNumberMap).hasSize(1);
+        var entry = channelNumberMap.entrySet().iterator().next();
+        assertThat(entry.getKey()).isEqualTo(1);
         ServerDevice.ChannelAndPreviousState value = entry.getValue();
         assertThat(value.channelUID()).isEqualTo(channelUID);
         assertThat((OnOffType) value.previousState()).isEqualTo(OFF);
@@ -115,9 +113,8 @@ class HandlerCommandTraitTest {
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
-    private static SuplaWriteFuture successfulWriteFuture(long messageId) {
+    private static SuplaWriteFuture successfulWriteFuture() {
         var future = mock(SuplaWriteFuture.class);
-        lenient().when(future.msgId()).thenReturn(messageId);
         lenient().when(future.addListener(any())).thenAnswer(invocation -> {
             var listener = (GenericFutureListener) invocation.getArgument(0);
             listener.operationComplete(future);


### PR DESCRIPTION
## Summary
- update jSupla server to 5.2.0-SNAPSHOT
- replace dynamic sender IDs with static SENDER_ID = 0
- correlate command/result handling with SuplaWriteFuture message IDs

## Tests
- mvn verify