### PR TITLE
Add software update thing properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,12 @@ Notes:
 	- `otaVersionAvailable`
 	- `otaChangelogUrl`
 	- `otaLastCheck`
+- After a native server device registers, the binding also checks `https://updates.supla.org/check-updates` and stores the direct update service result in thing properties:
+	- `softwareUpdateStatus`
+	- `softwareUpdateAvailable`
+	- `softwareUpdateVersion`
+	- `softwareUpdateUrl`
+	- `softwareUpdateLastCheck`
 - `startFirmwareUpdate()` and `startSecurityUpdate()` only trigger the device-side OTA process. No firmware binary is transferred through the SUPLA session.
 
 #### Example

--- a/src/integration-test/java/pl/grzeslowski/openhab/supla/internal/MainIT.java
+++ b/src/integration-test/java/pl/grzeslowski/openhab/supla/internal/MainIT.java
@@ -451,6 +451,14 @@ public class MainIT {
                 // but value validity time expires
                 // which means channels should be UNDEF
                 device.temperatureAndHumidityUpdated();
+                await().untilAsserted(() -> {
+                    var temperatureState = deviceCtx.openHabDevice().findChannelState("0", "temperature");
+                    assertThat(temperatureState).isEqualTo(new QuantityType<>(device.getTemperature(), CELSIUS));
+                });
+                await().untilAsserted(() -> {
+                    var humidityState = deviceCtx.openHabDevice().findChannelState("0", "humidity");
+                    assertThat(humidityState).isEqualTo(new QuantityType<>(device.getHumidity(), PERCENT));
+                });
                 log.info("Waiting for temperature channel to invalidate");
                 var temperatureChannelUid = new ChannelUID("supla:server-device:%s:0#temperature".formatted(guid));
                 await().timeout(device.getValidityTime().multipliedBy(2))

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/SuplaBindingConstants.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/SuplaBindingConstants.java
@@ -78,6 +78,11 @@ public class SuplaBindingConstants {
         public static final String OTA_VERSION_AVAILABLE_PROPERTY = "otaVersionAvailable";
         public static final String OTA_CHANGELOG_URL_PROPERTY = "otaChangelogUrl";
         public static final String OTA_LAST_CHECK_PROPERTY = "otaLastCheck";
+        public static final String SOFTWARE_UPDATE_AVAILABLE_PROPERTY = "softwareUpdateAvailable";
+        public static final String SOFTWARE_UPDATE_STATUS_PROPERTY = "softwareUpdateStatus";
+        public static final String SOFTWARE_UPDATE_VERSION_PROPERTY = "softwareUpdateVersion";
+        public static final String SOFTWARE_UPDATE_URL_PROPERTY = "softwareUpdateUrl";
+        public static final String SOFTWARE_UPDATE_LAST_CHECK_PROPERTY = "softwareUpdateLastCheck";
     }
 
     // CloudBridgeHandler

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandler.java
@@ -22,10 +22,12 @@ import static pl.grzeslowski.jsupla.protocol.api.consts.ProtoConsts.SUPLA_CONFIG
 import static pl.grzeslowski.jsupla.protocol.api.consts.ProtoConsts.SUPLA_PROTO_VERSION_MIN;
 import static pl.grzeslowski.openhab.supla.internal.GuidLogger.attachGuid;
 import static pl.grzeslowski.openhab.supla.internal.Localization.text;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.BINDING_ID;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.*;
 import static pl.grzeslowski.openhab.supla.internal.server.ByteArrayToHex.hexToBytes;
 
 import io.netty.handler.timeout.ReadTimeoutException;
+import java.io.IOException;
 import java.math.BigInteger;
 import java.net.SocketException;
 import java.text.SimpleDateFormat;
@@ -47,6 +49,7 @@ import lombok.ToString;
 import lombok.experimental.Delegate;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.common.ThreadPoolManager;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -99,6 +102,8 @@ import pl.grzeslowski.openhab.supla.internal.server.oh_config.DeviceConfiguratio
 import pl.grzeslowski.openhab.supla.internal.server.oh_config.ServerDeviceHandlerConfiguration;
 import pl.grzeslowski.openhab.supla.internal.server.oh_config.TimeoutConfiguration;
 import pl.grzeslowski.openhab.supla.internal.server.traits.*;
+import pl.grzeslowski.openhab.supla.internal.updates.SuplaUpdatesClient;
+import pl.grzeslowski.openhab.supla.internal.updates.SuplaUpdatesClient.Request;
 
 /** The {@link ServerSuplaDeviceHandler} is responsible for handling commands, which are sent to one of the channels. */
 @NonNullByDefault
@@ -111,6 +116,7 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
 
     private final long id = ID.incrementAndGet();
     private final ServerDeviceActionServiceRegistry actionServiceRegistry;
+    private final SuplaUpdatesClient updatesClient;
 
     @Getter
     protected Logger logger = LoggerFactory.getLogger(baseLogger());
@@ -152,6 +158,7 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
     private final AtomicReference<@Nullable DeviceCalCfgResult> deviceCalCfgResult = new AtomicReference<>();
     private final AtomicReference<@Nullable Integer> pendingOtaCheckSenderId = new AtomicReference<>();
     private final AtomicReference<@Nullable OtaStatus> otaCheckResult = new AtomicReference<>();
+    private final AtomicLong softwareUpdateCheckId = new AtomicLong();
 
     @Delegate(types = StateCache.class)
     private final StateCache stateCache = new InMemoryStateCache(logger);
@@ -174,8 +181,14 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
     }
 
     public ServerSuplaDeviceHandler(Thing thing, ServerDeviceActionServiceRegistry actionServiceRegistry) {
+        this(thing, actionServiceRegistry, new SuplaUpdatesClient());
+    }
+
+    ServerSuplaDeviceHandler(
+            Thing thing, ServerDeviceActionServiceRegistry actionServiceRegistry, SuplaUpdatesClient updatesClient) {
         super(thing);
         this.actionServiceRegistry = actionServiceRegistry;
+        this.updatesClient = updatesClient;
     }
 
     @Override
@@ -452,6 +465,7 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
 
         ping.start(requireNonNull(deviceConfiguration).timeoutConfiguration());
         ping.ping();
+        checkForSoftwareUpdate(registerEntity);
     }
 
     private void authorize(RegisterDeviceTrait registerEntity) throws InitializationException {
@@ -838,6 +852,75 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
         setProperty(
                 OTA_LAST_CHECK_PROPERTY,
                 Optional.ofNullable(checkedAt).map(Instant::toString).orElse(null));
+    }
+
+    private void checkForSoftwareUpdate(RegisterDeviceTrait registerEntity) {
+        var request = buildSoftwareUpdateRequest(registerEntity);
+        var checkId = softwareUpdateCheckId.incrementAndGet();
+        if (request == null) {
+            clearSoftwareUpdateState();
+            return;
+        }
+        updateSoftwareUpdateState(new SuplaUpdatesClient.Result(SuplaUpdatesClient.Status.CHECKING, null, null), null);
+        ThreadPoolManager.getPool(BINDING_ID)
+                .execute(() -> attachGuid(guid, () -> executeSoftwareUpdateCheck(checkId, request)));
+    }
+
+    private void executeSoftwareUpdateCheck(long checkId, SuplaUpdatesClient.Request request) {
+        try {
+            var result = updatesClient.checkUpdates(request);
+            if (softwareUpdateCheckId.get() == checkId) {
+                updateSoftwareUpdateState(result, now());
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            markSoftwareUpdateCheckError(checkId, request, e);
+        } catch (IOException | RuntimeException e) {
+            markSoftwareUpdateCheckError(checkId, request, e);
+        }
+    }
+
+    private void markSoftwareUpdateCheckError(long checkId, SuplaUpdatesClient.Request request, Exception exception) {
+        logger.debug("Could not check software update. request={}", request, exception);
+        if (softwareUpdateCheckId.get() == checkId) {
+            updateSoftwareUpdateState(
+                    new SuplaUpdatesClient.Result(SuplaUpdatesClient.Status.ERROR, null, null), now());
+        }
+    }
+
+    void updateSoftwareUpdateState(SuplaUpdatesClient.Result result, @Nullable Instant checkedAt) {
+        setProperty(SOFTWARE_UPDATE_STATUS_PROPERTY, result.status().name());
+        setProperty(SOFTWARE_UPDATE_AVAILABLE_PROPERTY, Boolean.toString(result.updateAvailable()));
+        setProperty(
+                SOFTWARE_UPDATE_VERSION_PROPERTY,
+                result.updateAvailable() ? emptyToNull(result.latestVersion()) : null);
+        setProperty(SOFTWARE_UPDATE_URL_PROPERTY, result.updateAvailable() ? emptyToNull(result.updateUrl()) : null);
+        setProperty(
+                SOFTWARE_UPDATE_LAST_CHECK_PROPERTY,
+                Optional.ofNullable(checkedAt).map(Instant::toString).orElse(null));
+    }
+
+    private void clearSoftwareUpdateState() {
+        setProperty(SOFTWARE_UPDATE_STATUS_PROPERTY, null);
+        setProperty(SOFTWARE_UPDATE_AVAILABLE_PROPERTY, null);
+        setProperty(SOFTWARE_UPDATE_VERSION_PROPERTY, null);
+        setProperty(SOFTWARE_UPDATE_URL_PROPERTY, null);
+        setProperty(SOFTWARE_UPDATE_LAST_CHECK_PROPERTY, null);
+    }
+
+    static @Nullable Request buildSoftwareUpdateRequest(RegisterDeviceTrait registerEntity) {
+        var manufacturerId = registerEntity.manufacturerId();
+        var productId = registerEntity.productId();
+        if (manufacturerId == null || productId == null) {
+            return null;
+        }
+        var productName = Optional.ofNullable(buildProductNameProperty(manufacturerId, productId))
+                .or(() -> Optional.ofNullable(emptyToNull(registerEntity.name())))
+                .orElse(null);
+        if (productName == null) {
+            return null;
+        }
+        return new Request(manufacturerId, productId, productName, emptyToNull(registerEntity.softVer()));
     }
 
     private static @Nullable String emptyToNull(@Nullable String value) {

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandler.java
@@ -38,6 +38,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
 import java.util.*;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
@@ -112,6 +113,7 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
         implements MessageHandler, ServerDevice, Ping.DeviceStatusUpdater {
     public static final byte ACTIVITY_TIMEOUT = (byte) 100;
     public static final String AVAILABLE_FIELDS = "AVAILABLE_FIELDS";
+    private static final String SOFTWARE_UPDATE_THREAD_POOL_NAME = BINDING_ID + "-software-update";
     private static final AtomicLong ID = new AtomicLong();
 
     private final long id = ID.incrementAndGet();
@@ -158,6 +160,7 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
     private final AtomicReference<@Nullable DeviceCalCfgResult> deviceCalCfgResult = new AtomicReference<>();
     private final AtomicReference<@Nullable Integer> pendingOtaCheckSenderId = new AtomicReference<>();
     private final AtomicReference<@Nullable OtaStatus> otaCheckResult = new AtomicReference<>();
+    private final AtomicReference<@Nullable Future<?>> softwareUpdateCheckFuture = new AtomicReference<>();
     private final AtomicLong softwareUpdateCheckId = new AtomicLong();
 
     @Delegate(types = StateCache.class)
@@ -589,6 +592,7 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
         attachGuid(findGuid(), () -> {
             logger.debug("Disposing handler");
             disposePing();
+            cancelSoftwareUpdateCheck();
             disposeHandler();
             disposeBridgeHandler();
             actionServiceRegistry.unregisterActionServices(this);
@@ -855,6 +859,7 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
     }
 
     private void checkForSoftwareUpdate(RegisterDeviceTrait registerEntity) {
+        cancelSoftwareUpdateCheck();
         var request = buildSoftwareUpdateRequest(registerEntity);
         var checkId = softwareUpdateCheckId.incrementAndGet();
         if (request == null) {
@@ -862,8 +867,13 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
             return;
         }
         updateSoftwareUpdateState(new SuplaUpdatesClient.Result(SuplaUpdatesClient.Status.CHECKING, null, null), null);
-        ThreadPoolManager.getPool(BINDING_ID)
-                .execute(() -> attachGuid(guid, () -> executeSoftwareUpdateCheck(checkId, request)));
+        softwareUpdateCheckFuture.set(ThreadPoolManager.getPool(SOFTWARE_UPDATE_THREAD_POOL_NAME)
+                .submit(() -> attachGuid(guid, () -> executeSoftwareUpdateCheck(checkId, request))));
+    }
+
+    private void cancelSoftwareUpdateCheck() {
+        softwareUpdateCheckId.incrementAndGet();
+        Optional.ofNullable(softwareUpdateCheckFuture.getAndSet(null)).ifPresent(future -> future.cancel(true));
     }
 
     private void executeSoftwareUpdateCheck(long checkId, SuplaUpdatesClient.Request request) {
@@ -881,11 +891,12 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
     }
 
     private void markSoftwareUpdateCheckError(long checkId, SuplaUpdatesClient.Request request, Exception exception) {
-        logger.debug("Could not check software update. request={}", request, exception);
-        if (softwareUpdateCheckId.get() == checkId) {
-            updateSoftwareUpdateState(
-                    new SuplaUpdatesClient.Result(SuplaUpdatesClient.Status.ERROR, null, null), now());
+        if (softwareUpdateCheckId.get() != checkId) {
+            logger.trace("Ignoring software update check error for stale request. request={}", request);
+            return;
         }
+        logger.debug("Could not check software update. request={}", request, exception);
+        updateSoftwareUpdateState(new SuplaUpdatesClient.Result(SuplaUpdatesClient.Status.ERROR, null, null), now());
     }
 
     void updateSoftwareUpdateState(SuplaUpdatesClient.Result result, @Nullable Instant checkedAt) {

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/updates/SuplaUpdatesClient.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/updates/SuplaUpdatesClient.java
@@ -1,0 +1,172 @@
+package pl.grzeslowski.openhab.supla.internal.updates;
+
+import static java.net.URLEncoder.encode;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.stream;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toUnmodifiableMap;
+
+import com.google.gson.Gson;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+import java.util.Map;
+import java.util.StringJoiner;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+@NonNullByDefault
+public class SuplaUpdatesClient {
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+    private static final URI CHECK_UPDATES_URI = URI.create("https://updates.supla.org/check-updates");
+
+    private final HttpClient httpClient;
+    private final URI checkUpdatesUri;
+    private final Gson gson = new Gson();
+
+    public SuplaUpdatesClient() {
+        this(
+                HttpClient.newBuilder()
+                        .connectTimeout(REQUEST_TIMEOUT)
+                        .followRedirects(HttpClient.Redirect.NORMAL)
+                        .build(),
+                CHECK_UPDATES_URI);
+    }
+
+    SuplaUpdatesClient(HttpClient httpClient, URI checkUpdatesUri) {
+        this.httpClient = httpClient;
+        this.checkUpdatesUri = checkUpdatesUri;
+    }
+
+    public Result checkUpdates(Request request) throws IOException, InterruptedException {
+        var httpRequest = HttpRequest.newBuilder(buildUri(checkUpdatesUri, request))
+                .timeout(REQUEST_TIMEOUT)
+                .GET()
+                .build();
+        var response = httpClient.send(httpRequest, BodyHandlers.ofString(UTF_8));
+        if (response.statusCode() != 200) {
+            throw new IOException("Unexpected update check response status " + response.statusCode());
+        }
+        return parseResponse(response.body());
+    }
+
+    static URI buildUri(URI baseUri, Request request) {
+        var query = new StringJoiner("&");
+        addQueryParam(query, "manufacturerId", Integer.toString(request.manufacturerId()));
+        addQueryParam(query, "productId", Integer.toString(request.productId()));
+        addQueryParam(query, "productName", request.productName());
+        if (request.version() != null && !request.version().isBlank()) {
+            addQueryParam(query, "version", request.version());
+        }
+
+        var base = baseUri.toString();
+        var separator = base.contains("?") ? "&" : "?";
+        return URI.create(base + separator + query);
+    }
+
+    Result parseResponse(String responseBody) throws IOException {
+        var response = gson.fromJson(responseBody, Response.class);
+        if (response == null || response.status == null) {
+            throw new IOException("Update check response does not contain status");
+        }
+        var status = Status.fromApiStatus(response.status);
+        var latestUpdate = response.latestUpdate;
+        return new Result(
+                status,
+                latestUpdate == null ? null : emptyToNull(latestUpdate.version),
+                latestUpdate == null ? null : emptyToNull(latestUpdate.updateUrl));
+    }
+
+    private static void addQueryParam(StringJoiner query, String name, String value) {
+        query.add(encode(name, UTF_8) + "=" + encode(value, UTF_8));
+    }
+
+    private static @Nullable String emptyToNull(@Nullable String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value;
+    }
+
+    public record Request(
+            int manufacturerId,
+            int productId,
+            String productName,
+            @Nullable String version) {
+        public Request {
+            requireNonNull(productName);
+        }
+    }
+
+    public record Result(
+            Status status,
+            @Nullable String latestVersion,
+            @Nullable String updateUrl) {
+        public Result {
+            requireNonNull(status);
+        }
+
+        public boolean updateAvailable() {
+            return status.updateAvailable();
+        }
+    }
+
+    public enum Status {
+        CHECKING(null, false),
+        UPDATE_NOT_AVAILABLE("Update not available", false),
+        UPDATE_AVAILABLE("Update available", true),
+        GUID_SPECIFIC_UPDATE_AVAILABLE("GUID specific update available", true),
+        MAIL_SPECIFIC_UPDATE_AVAILABLE("Mail specific update available", true),
+        BETA_UPDATE_AVAILABLE("BETA update available", true),
+        OTA_TEST_UPDATE_AVAILABLE("OTA test update available", true),
+        UNKNOWN_PRODUCT("Unknown product", false),
+        ERROR(null, false);
+
+        private static final Map<String, Status> API_STATUSES = stream(values())
+                .filter(status -> status.apiStatus != null)
+                .collect(toUnmodifiableMap(status -> requireNonNull(status.apiStatus), status -> status));
+
+        @Nullable
+        private final String apiStatus;
+
+        private final boolean updateAvailable;
+
+        Status(@Nullable String apiStatus, boolean updateAvailable) {
+            this.apiStatus = apiStatus;
+            this.updateAvailable = updateAvailable;
+        }
+
+        static Status fromApiStatus(String apiStatus) throws IOException {
+            var status = API_STATUSES.get(apiStatus);
+            if (status == null) {
+                throw new IOException("Unknown update check status " + apiStatus);
+            }
+            return status;
+        }
+
+        public boolean updateAvailable() {
+            return updateAvailable;
+        }
+    }
+
+    @SuppressWarnings("MemberName")
+    private static class Response {
+        @Nullable
+        String status;
+
+        @Nullable
+        UpdateEntry latestUpdate;
+    }
+
+    @SuppressWarnings("MemberName")
+    private static class UpdateEntry {
+        @Nullable
+        String version;
+
+        @Nullable
+        String updateUrl;
+    }
+}

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandlerTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandlerTest.java
@@ -19,8 +19,14 @@ import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.Server
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.OTA_LAST_CHECK_PROPERTY;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.OTA_STATUS_PROPERTY;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.OTA_VERSION_AVAILABLE_PROPERTY;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.SOFTWARE_UPDATE_AVAILABLE_PROPERTY;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.SOFTWARE_UPDATE_LAST_CHECK_PROPERTY;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.SOFTWARE_UPDATE_STATUS_PROPERTY;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.SOFTWARE_UPDATE_URL_PROPERTY;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.SOFTWARE_UPDATE_VERSION_PROPERTY;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +46,7 @@ import pl.grzeslowski.openhab.supla.actions.SuplaServerElectricityMeterActions;
 import pl.grzeslowski.openhab.supla.actions.SuplaServerFirmwareUpdateActions;
 import pl.grzeslowski.openhab.supla.internal.server.traits.DeviceChannel;
 import pl.grzeslowski.openhab.supla.internal.server.traits.RegisterEmailDeviceTrait;
+import pl.grzeslowski.openhab.supla.internal.updates.SuplaUpdatesClient;
 
 class ServerSuplaDeviceHandlerTest {
     private static final int FIRMWARE_CHECK_SENDER_ID = 37;
@@ -123,6 +130,64 @@ class ServerSuplaDeviceHandlerTest {
                 .isNull();
         assertThat(ServerSuplaDeviceHandler.buildProductNameProperty(4, null)).isNull();
         assertThat(ServerSuplaDeviceHandler.buildProductNameProperty(999, 999)).isNull();
+    }
+
+    @Test
+    void shouldBuildSoftwareUpdateRequestFromRegisteredDevice() {
+        var registerEntity = new RegisterEmailDeviceTrait(
+                "guid", "device", "1.2.3", 4, 6000, Set.of(), List.of(), "test@example.org", new byte[0], "server");
+
+        var request = ServerSuplaDeviceHandler.buildSoftwareUpdateRequest(registerEntity);
+
+        assertThat(request).isNotNull();
+        assertThat(request.manufacturerId()).isEqualTo(4);
+        assertThat(request.productId()).isEqualTo(6000);
+        assertThat(request.productName()).isEqualTo("ZAMEL THW-01");
+        assertThat(request.version()).isEqualTo("1.2.3");
+    }
+
+    @Test
+    void shouldNotBuildSoftwareUpdateRequestWhenIdsAreMissing() {
+        var registerEntity = new RegisterEmailDeviceTrait(
+                "guid", "device", "1.2.3", null, 6000, Set.of(), List.of(), "test@example.org", new byte[0], "server");
+
+        assertThat(ServerSuplaDeviceHandler.buildSoftwareUpdateRequest(registerEntity))
+                .isNull();
+    }
+
+    @Test
+    void shouldPersistAvailableSoftwareUpdateResult() {
+        var checkedAt = Instant.parse("2026-04-28T10:15:30Z");
+
+        handler.updateSoftwareUpdateState(
+                new SuplaUpdatesClient.Result(
+                        SuplaUpdatesClient.Status.UPDATE_AVAILABLE, "2.0.0", "https://updates.example/device"),
+                checkedAt);
+
+        assertThat(properties.get(SOFTWARE_UPDATE_STATUS_PROPERTY)).isEqualTo("UPDATE_AVAILABLE");
+        assertThat(properties.get(SOFTWARE_UPDATE_AVAILABLE_PROPERTY)).isEqualTo("true");
+        assertThat(properties.get(SOFTWARE_UPDATE_VERSION_PROPERTY)).isEqualTo("2.0.0");
+        assertThat(properties.get(SOFTWARE_UPDATE_URL_PROPERTY)).isEqualTo("https://updates.example/device");
+        assertThat(properties.get(SOFTWARE_UPDATE_LAST_CHECK_PROPERTY)).isEqualTo(checkedAt.toString());
+    }
+
+    @Test
+    void shouldClearSoftwareUpdateVersionWhenUpdateIsNotAvailable() {
+        properties.put(SOFTWARE_UPDATE_VERSION_PROPERTY, "2.0.0");
+        properties.put(SOFTWARE_UPDATE_URL_PROPERTY, "https://updates.example/device");
+        var checkedAt = Instant.parse("2026-04-28T10:15:30Z");
+
+        handler.updateSoftwareUpdateState(
+                new SuplaUpdatesClient.Result(
+                        SuplaUpdatesClient.Status.UPDATE_NOT_AVAILABLE, "2.0.0", "https://updates.example/device"),
+                checkedAt);
+
+        assertThat(properties.get(SOFTWARE_UPDATE_STATUS_PROPERTY)).isEqualTo("UPDATE_NOT_AVAILABLE");
+        assertThat(properties.get(SOFTWARE_UPDATE_AVAILABLE_PROPERTY)).isEqualTo("false");
+        assertThat(properties)
+                .doesNotContainKey(SOFTWARE_UPDATE_VERSION_PROPERTY)
+                .doesNotContainKey(SOFTWARE_UPDATE_URL_PROPERTY);
+        assertThat(properties.get(SOFTWARE_UPDATE_LAST_CHECK_PROPERTY)).isEqualTo(checkedAt.toString());
     }
 
     @Test

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/updates/SuplaUpdatesClientTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/updates/SuplaUpdatesClientTest.java
@@ -1,0 +1,69 @@
+package pl.grzeslowski.openhab.supla.internal.updates;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+
+class SuplaUpdatesClientTest {
+    private final SuplaUpdatesClient client = new SuplaUpdatesClient();
+
+    @Test
+    void shouldBuildCheckUpdatesUri() {
+        var uri = SuplaUpdatesClient.buildUri(
+                URI.create("https://updates.supla.org/check-updates"),
+                new SuplaUpdatesClient.Request(4, 6000, "ZAMEL THW-01", "1.2.3"));
+
+        assertThat(uri.toString())
+                .isEqualTo(
+                        "https://updates.supla.org/check-updates?manufacturerId=4&productId=6000&productName=ZAMEL+THW-01&version=1.2.3");
+    }
+
+    @Test
+    void shouldSkipBlankVersionWhenBuildingUri() {
+        var uri = SuplaUpdatesClient.buildUri(
+                URI.create("https://updates.supla.org/check-updates"),
+                new SuplaUpdatesClient.Request(4, 6000, "ZAMEL THW-01", " "));
+
+        assertThat(uri.toString())
+                .isEqualTo(
+                        "https://updates.supla.org/check-updates?manufacturerId=4&productId=6000&productName=ZAMEL+THW-01");
+    }
+
+    @Test
+    void shouldParseAvailableUpdateResponse() throws Exception {
+        var result = client.parseResponse("""
+                {
+                  "status": "Update available",
+                  "latestUpdate": {
+                    "version": "2.0.0",
+                    "updateUrl": "https://updates.example/device"
+                  }
+                }
+                """);
+
+        assertThat(result.status()).isEqualTo(SuplaUpdatesClient.Status.UPDATE_AVAILABLE);
+        assertThat(result.updateAvailable()).isTrue();
+        assertThat(result.latestVersion()).isEqualTo("2.0.0");
+        assertThat(result.updateUrl()).isEqualTo("https://updates.example/device");
+    }
+
+    @Test
+    void shouldParseNotAvailableUpdateResponse() throws Exception {
+        var result = client.parseResponse("{\"status\":\"Update not available\"}");
+
+        assertThat(result.status()).isEqualTo(SuplaUpdatesClient.Status.UPDATE_NOT_AVAILABLE);
+        assertThat(result.updateAvailable()).isFalse();
+        assertThat(result.latestVersion()).isNull();
+        assertThat(result.updateUrl()).isNull();
+    }
+
+    @Test
+    void shouldRejectUnknownStatus() {
+        assertThatThrownBy(() -> client.parseResponse("{\"status\":\"Unexpected\"}"))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Unknown update check status");
+    }
+}


### PR DESCRIPTION
## Summary
- add a updates.supla.org client for /check-updates
- check native server devices after registration and persist software update thing properties
- document the new properties and cover request/response/property behavior with tests

## Tests
- mvn spotless:apply
- mvn test