### PR TITLE
Expose ProductInfo fields as thing properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ However, it's important to note that by opting for this setup, you lose the inte
 won't have remote access through the Supla Cloud app or benefit from cloud-based services and updates provided by Supla.
 Ensure this trade-off aligns with your smart home requirements before proceeding with the native device configuration.
 
+After a native server device registers, the binding stores Supla product catalog metadata in thing properties when the
+manufacturer and product IDs are known:
+
+- `productManufacturer`
+- `productName`
+- `productUpdatesCount`
+- `productLatestReleaseAt`
+- `productLatestVersion`
+- `productLatestDescription`
+- `productUrl`
+
 ## Cloud
 
 To connect your Supla cloud devices to OpenHAB, you'll need to use the Supla Cloud Bridge. This bridge facilitates

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>pl.grzeslowski.jSupla</groupId>
             <artifactId>server</artifactId>
-            <version>5.0.2-SNAPSHOT</version>
+            <version>5.2.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/SuplaBindingConstants.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/SuplaBindingConstants.java
@@ -68,8 +68,14 @@ public class SuplaBindingConstants {
         public static final String SOFT_VERSION_PROPERTY = "softVersion";
         public static final String MANUFACTURER_ID_PROPERTY = "manufacturerId";
         public static final String PRODUCT_ID_PROPERTY = "productId";
+        public static final String PRODUCT_MANUFACTURER_PROPERTY = "productManufacturer";
         public static final String PRODUCT_NAME_PROPERTY = "productName";
         public static final String PRODUCT_CODE_PROPERTY = "productCode";
+        public static final String PRODUCT_UPDATES_COUNT_PROPERTY = "productUpdatesCount";
+        public static final String PRODUCT_LATEST_RELEASE_AT_PROPERTY = "productLatestReleaseAt";
+        public static final String PRODUCT_LATEST_VERSION_PROPERTY = "productLatestVersion";
+        public static final String PRODUCT_LATEST_DESCRIPTION_PROPERTY = "productLatestDescription";
+        public static final String PRODUCT_URL_PROPERTY = "productUrl";
         public static final String CONFIG_AUTH_PROPERTY = "authKey";
         public static final String SERVER_NAME_PROPERTY = "serverName";
         public static final String SERIAL_NUMBER_PROPERTY = "serialNumber";

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandler.java
@@ -417,10 +417,8 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
             if (registerEntity.productId() != null) {
                 thing.setProperty(PRODUCT_ID_PROPERTY, valueOf(registerEntity.productId()));
             }
-            var productName = buildProductNameProperty(registerEntity.manufacturerId(), registerEntity.productId());
-            if (productName != null) {
-                thing.setProperty(PRODUCT_NAME_PROPERTY, productName);
-            }
+            buildProductInfoProperties(registerEntity.manufacturerId(), registerEntity.productId())
+                    .forEach(thing::setProperty);
         }
 
         actionChannels = registerEntity.channels().stream()
@@ -983,8 +981,38 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
             return null;
         }
         return SuplaProducts.findByIds(manufacturerId, productId)
-                .map(SuplaProducts.ProductInfo::description)
+                .map(SuplaProducts.ProductInfo::name)
                 .orElse(null);
+    }
+
+    static Map<String, String> buildProductInfoProperties(
+            @Nullable Integer manufacturerId, @Nullable Integer productId) {
+        if (manufacturerId == null || productId == null) {
+            return Map.of();
+        }
+        return SuplaProducts.findByIds(manufacturerId, productId)
+                .<Map<String, String>>map(productInfo -> {
+                    var properties = new LinkedHashMap<String, String>();
+                    putProductInfoProperty(properties, PRODUCT_MANUFACTURER_PROPERTY, productInfo.manufacturer());
+                    putProductInfoProperty(properties, PRODUCT_NAME_PROPERTY, productInfo.name());
+                    properties.put(PRODUCT_UPDATES_COUNT_PROPERTY, valueOf(productInfo.updatesCount()));
+                    putProductInfoProperty(
+                            properties, PRODUCT_LATEST_RELEASE_AT_PROPERTY, productInfo.latestReleaseAt());
+                    putProductInfoProperty(properties, PRODUCT_LATEST_VERSION_PROPERTY, productInfo.latestVersion());
+                    putProductInfoProperty(
+                            properties, PRODUCT_LATEST_DESCRIPTION_PROPERTY, productInfo.latestDescription());
+                    putProductInfoProperty(properties, PRODUCT_URL_PROPERTY, productInfo.productUrl());
+                    return properties;
+                })
+                .orElseGet(Map::of);
+    }
+
+    private static void putProductInfoProperty(
+            Map<String, String> properties, String property, @Nullable String value) {
+        var valueToSet = emptyToNull(value);
+        if (valueToSet != null) {
+            properties.put(property, valueToSet);
+        }
     }
 
     private static String formatEnums(Collection<? extends Enum<?>> values) {

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandler.java
@@ -115,6 +115,16 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
     public static final String AVAILABLE_FIELDS = "AVAILABLE_FIELDS";
     private static final String SOFTWARE_UPDATE_THREAD_POOL_NAME = BINDING_ID + "-software-update";
     private static final AtomicLong ID = new AtomicLong();
+    private static final Set<String> PRODUCT_INFO_PROPERTIES = Set.of(
+            MANUFACTURER_ID_PROPERTY,
+            PRODUCT_ID_PROPERTY,
+            PRODUCT_MANUFACTURER_PROPERTY,
+            PRODUCT_NAME_PROPERTY,
+            PRODUCT_UPDATES_COUNT_PROPERTY,
+            PRODUCT_LATEST_RELEASE_AT_PROPERTY,
+            PRODUCT_LATEST_VERSION_PROPERTY,
+            PRODUCT_LATEST_DESCRIPTION_PROPERTY,
+            PRODUCT_URL_PROPERTY);
 
     private final long id = ID.incrementAndGet();
     private final ServerDeviceActionServiceRegistry actionServiceRegistry;
@@ -410,6 +420,7 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
         }
 
         { // set properties
+            clearProductInfoProperties();
             thing.setProperty(SOFT_VERSION_PROPERTY, registerEntity.softVer());
             if (registerEntity.manufacturerId() != null) {
                 thing.setProperty(MANUFACTURER_ID_PROPERTY, valueOf(registerEntity.manufacturerId()));
@@ -1031,6 +1042,13 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
                 .filter(key -> key.startsWith("CHANNEL_FLAGS_")
                         || key.startsWith("CHANNEL_FUNCTION_")
                         || key.startsWith("CHANNEL_FUNCTIONS_"))
+                .forEach(key -> thing.setProperty(key, null));
+    }
+
+    void clearProductInfoProperties() {
+        thing.getProperties().keySet().stream()
+                .filter(PRODUCT_INFO_PROPERTIES::contains)
+                .toList()
                 .forEach(key -> thing.setProperty(key, null));
     }
 

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/SuplaServerActionsTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/SuplaServerActionsTest.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.openhab.core.thing.ThingStatus.OFFLINE;
@@ -20,9 +21,6 @@ import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ACTION
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ACTION_SCOPE_ELECTRICITY_METER;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ACTION_SCOPE_FIRMWARE_UPDATE;
 
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.DefaultChannelPromise;
-import io.netty.channel.embedded.EmbeddedChannel;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
@@ -41,6 +39,7 @@ import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.ThingActionsScope;
 import pl.grzeslowski.jsupla.protocol.api.structs.ds.DeviceCalCfgResult;
 import pl.grzeslowski.jsupla.protocol.api.structs.sd.DeviceCalCfgRequest;
+import pl.grzeslowski.jsupla.server.SuplaWriteFuture;
 import pl.grzeslowski.jsupla.server.SuplaWriter;
 import pl.grzeslowski.openhab.supla.actions.SuplaServerConfigModeActions;
 import pl.grzeslowski.openhab.supla.actions.SuplaServerDeviceConfigActions;
@@ -63,17 +62,17 @@ class SuplaServerActionsTest {
     @Mock
     private Thing thing;
 
+    @Mock
+    private SuplaWriteFuture successfulFuture;
+
     private SuplaServerElectricityMeterActions electricityMeterActions;
     private SuplaServerConfigModeActions configModeActions;
     private SuplaServerFirmwareUpdateActions firmwareUpdateActions;
 
     private ServerDeviceHandlerConfiguration configuration;
-    private ChannelFuture successfulFuture;
 
     @BeforeEach
     void setUp() {
-        var channel = new EmbeddedChannel();
-        successfulFuture = new DefaultChannelPromise(channel).setSuccess(null);
         configuration = new ServerDeviceHandlerConfiguration();
         electricityMeterActions = new SuplaServerElectricityMeterActions();
         configModeActions = new SuplaServerConfigModeActions();
@@ -107,6 +106,7 @@ class SuplaServerActionsTest {
         org.mockito.Mockito.lenient()
                 .when(handler.supportsAutomaticFirmwareUpdates())
                 .thenReturn(true);
+        org.mockito.Mockito.lenient().when(successfulFuture.isSuccess()).thenReturn(true);
         org.mockito.Mockito.lenient()
                 .when(writer.write(argThat(proto -> proto instanceof DeviceCalCfgRequest)))
                 .thenReturn(successfulFuture);
@@ -440,8 +440,10 @@ class SuplaServerActionsTest {
 
     @Test
     void shouldFailWhenCheckFirmwareUpdateDispatchFutureIsFailed() {
-        var channel = new EmbeddedChannel();
-        var failedFuture = new DefaultChannelPromise(channel).setFailure(new IllegalStateException("write failed"));
+        var dispatchFailure = new IllegalStateException("write failed");
+        var failedFuture = mock(SuplaWriteFuture.class);
+        when(failedFuture.isSuccess()).thenReturn(false);
+        when(failedFuture.cause()).thenReturn(dispatchFailure);
         when(writer.write(argThat(proto -> proto instanceof DeviceCalCfgRequest)))
                 .thenReturn(failedFuture);
 

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandlerTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandlerTest.java
@@ -19,6 +19,13 @@ import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.Server
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.OTA_LAST_CHECK_PROPERTY;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.OTA_STATUS_PROPERTY;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.OTA_VERSION_AVAILABLE_PROPERTY;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.PRODUCT_LATEST_DESCRIPTION_PROPERTY;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.PRODUCT_LATEST_RELEASE_AT_PROPERTY;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.PRODUCT_LATEST_VERSION_PROPERTY;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.PRODUCT_MANUFACTURER_PROPERTY;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.PRODUCT_NAME_PROPERTY;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.PRODUCT_UPDATES_COUNT_PROPERTY;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.PRODUCT_URL_PROPERTY;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.SOFTWARE_UPDATE_AVAILABLE_PROPERTY;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.SOFTWARE_UPDATE_LAST_CHECK_PROPERTY;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.SOFTWARE_UPDATE_STATUS_PROPERTY;
@@ -37,6 +44,7 @@ import org.mockito.Mockito;
 import org.openhab.core.thing.Thing;
 import pl.grzeslowski.jsupla.protocol.api.BitFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelFlag;
+import pl.grzeslowski.jsupla.protocol.api.SuplaProducts;
 import pl.grzeslowski.jsupla.protocol.api.encoders.FirmwareCheckResultEncoder;
 import pl.grzeslowski.jsupla.protocol.api.structs.FirmwareCheckResult;
 import pl.grzeslowski.jsupla.protocol.api.structs.ds.DeviceCalCfgResult;
@@ -125,11 +133,32 @@ class ServerSuplaDeviceHandlerTest {
     }
 
     @Test
+    void shouldBuildProductInfoPropertiesFromManufacturerAndProductIds() {
+        var productInfo = SuplaProducts.findByIds(4, 6000).orElseThrow();
+
+        var properties = ServerSuplaDeviceHandler.buildProductInfoProperties(4, 6000);
+
+        assertThat(properties)
+                .containsEntry(PRODUCT_MANUFACTURER_PROPERTY, productInfo.manufacturer())
+                .containsEntry(PRODUCT_NAME_PROPERTY, productInfo.name())
+                .containsEntry(PRODUCT_UPDATES_COUNT_PROPERTY, Integer.toString(productInfo.updatesCount()))
+                .containsEntry(PRODUCT_LATEST_RELEASE_AT_PROPERTY, productInfo.latestReleaseAt())
+                .containsEntry(PRODUCT_LATEST_VERSION_PROPERTY, productInfo.latestVersion())
+                .containsEntry(PRODUCT_LATEST_DESCRIPTION_PROPERTY, productInfo.latestDescription())
+                .containsEntry(PRODUCT_URL_PROPERTY, productInfo.productUrl());
+    }
+
+    @Test
     void shouldNotBuildProductNamePropertyWhenAnyIdIsMissing() {
         assertThat(ServerSuplaDeviceHandler.buildProductNameProperty(null, 6000))
                 .isNull();
         assertThat(ServerSuplaDeviceHandler.buildProductNameProperty(4, null)).isNull();
         assertThat(ServerSuplaDeviceHandler.buildProductNameProperty(999, 999)).isNull();
+        assertThat(ServerSuplaDeviceHandler.buildProductInfoProperties(null, 6000))
+                .isEmpty();
+        assertThat(ServerSuplaDeviceHandler.buildProductInfoProperties(4, null)).isEmpty();
+        assertThat(ServerSuplaDeviceHandler.buildProductInfoProperties(999, 999))
+                .isEmpty();
     }
 
     @Test

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandlerTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandlerTest.java
@@ -15,10 +15,12 @@ import static pl.grzeslowski.jsupla.protocol.api.ChannelType.SUPLA_CHANNELTYPE_E
 import static pl.grzeslowski.jsupla.protocol.api.DeviceFlag.SUPLA_DEVICE_FLAG_AUTOMATIC_FIRMWARE_UPDATE_SUPPORTED;
 import static pl.grzeslowski.jsupla.protocol.api.DeviceFlag.SUPLA_DEVICE_FLAG_CALCFG_ENTER_CFG_MODE;
 import static pl.grzeslowski.jsupla.protocol.api.FirmwareCheckResultCode.*;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.MANUFACTURER_ID_PROPERTY;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.OTA_CHANGELOG_URL_PROPERTY;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.OTA_LAST_CHECK_PROPERTY;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.OTA_STATUS_PROPERTY;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.OTA_VERSION_AVAILABLE_PROPERTY;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.PRODUCT_ID_PROPERTY;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.PRODUCT_LATEST_DESCRIPTION_PROPERTY;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.PRODUCT_LATEST_RELEASE_AT_PROPERTY;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.PRODUCT_LATEST_VERSION_PROPERTY;
@@ -217,6 +219,35 @@ class ServerSuplaDeviceHandlerTest {
                 .doesNotContainKey(SOFTWARE_UPDATE_VERSION_PROPERTY)
                 .doesNotContainKey(SOFTWARE_UPDATE_URL_PROPERTY);
         assertThat(properties.get(SOFTWARE_UPDATE_LAST_CHECK_PROPERTY)).isEqualTo(checkedAt.toString());
+    }
+
+    @Test
+    void shouldClearProductInfoProperties() {
+        properties.put("OTHER", "preserved");
+        properties.put(MANUFACTURER_ID_PROPERTY, "4");
+        properties.put(PRODUCT_ID_PROPERTY, "6000");
+        properties.put(PRODUCT_MANUFACTURER_PROPERTY, "Zamel");
+        properties.put(PRODUCT_NAME_PROPERTY, "THW-01");
+        properties.put(PRODUCT_UPDATES_COUNT_PROPERTY, "1");
+        properties.put(PRODUCT_LATEST_RELEASE_AT_PROPERTY, "2024-09-05");
+        properties.put(PRODUCT_LATEST_VERSION_PROPERTY, "1.0.0");
+        properties.put(PRODUCT_LATEST_DESCRIPTION_PROPERTY, "desc");
+        properties.put(PRODUCT_URL_PROPERTY, "https://example.org");
+
+        handler.clearProductInfoProperties();
+
+        assertThat(properties)
+                .containsEntry("OTHER", "preserved")
+                .doesNotContainKeys(
+                        MANUFACTURER_ID_PROPERTY,
+                        PRODUCT_ID_PROPERTY,
+                        PRODUCT_MANUFACTURER_PROPERTY,
+                        PRODUCT_NAME_PROPERTY,
+                        PRODUCT_UPDATES_COUNT_PROPERTY,
+                        PRODUCT_LATEST_RELEASE_AT_PROPERTY,
+                        PRODUCT_LATEST_VERSION_PROPERTY,
+                        PRODUCT_LATEST_DESCRIPTION_PROPERTY,
+                        PRODUCT_URL_PROPERTY);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- bump JSupla server to 5.2.0-SNAPSHOT for the expanded ProductInfo catalog
- expose ProductInfo catalog fields as native server thing properties
- update tests for ProductInfo properties and SuplaWriteFuture stubs

## Tests
- mvn spotless:apply
- mvn -Dtest=ServerSuplaDeviceHandlerTest,SuplaServerActionsTest test
- mvn test