### PR TITLE
Clear stale product-info properties on server re-registration

### DIFF
--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandler.java
@@ -115,6 +115,16 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
     public static final String AVAILABLE_FIELDS = "AVAILABLE_FIELDS";
     private static final String SOFTWARE_UPDATE_THREAD_POOL_NAME = BINDING_ID + "-software-update";
     private static final AtomicLong ID = new AtomicLong();
+    private static final Set<String> PRODUCT_INFO_PROPERTIES = Set.of(
+            MANUFACTURER_ID_PROPERTY,
+            PRODUCT_ID_PROPERTY,
+            PRODUCT_MANUFACTURER_PROPERTY,
+            PRODUCT_NAME_PROPERTY,
+            PRODUCT_UPDATES_COUNT_PROPERTY,
+            PRODUCT_LATEST_RELEASE_AT_PROPERTY,
+            PRODUCT_LATEST_VERSION_PROPERTY,
+            PRODUCT_LATEST_DESCRIPTION_PROPERTY,
+            PRODUCT_URL_PROPERTY);
 
     private final long id = ID.incrementAndGet();
     private final ServerDeviceActionServiceRegistry actionServiceRegistry;
@@ -410,6 +420,7 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
         }
 
         { // set properties
+            clearProductInfoProperties();
             thing.setProperty(SOFT_VERSION_PROPERTY, registerEntity.softVer());
             if (registerEntity.manufacturerId() != null) {
                 thing.setProperty(MANUFACTURER_ID_PROPERTY, valueOf(registerEntity.manufacturerId()));
@@ -1031,6 +1042,13 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
                 .filter(key -> key.startsWith("CHANNEL_FLAGS_")
                         || key.startsWith("CHANNEL_FUNCTION_")
                         || key.startsWith("CHANNEL_FUNCTIONS_"))
+                .forEach(key -> thing.setProperty(key, null));
+    }
+
+    void clearProductInfoProperties() {
+        thing.getProperties().keySet().stream()
+                .filter(PRODUCT_INFO_PROPERTIES::contains)
+                .toList()
                 .forEach(key -> thing.setProperty(key, null));
     }
 

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandlerTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandlerTest.java
@@ -15,10 +15,12 @@ import static pl.grzeslowski.jsupla.protocol.api.ChannelType.SUPLA_CHANNELTYPE_E
 import static pl.grzeslowski.jsupla.protocol.api.DeviceFlag.SUPLA_DEVICE_FLAG_AUTOMATIC_FIRMWARE_UPDATE_SUPPORTED;
 import static pl.grzeslowski.jsupla.protocol.api.DeviceFlag.SUPLA_DEVICE_FLAG_CALCFG_ENTER_CFG_MODE;
 import static pl.grzeslowski.jsupla.protocol.api.FirmwareCheckResultCode.*;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.MANUFACTURER_ID_PROPERTY;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.OTA_CHANGELOG_URL_PROPERTY;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.OTA_LAST_CHECK_PROPERTY;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.OTA_STATUS_PROPERTY;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.OTA_VERSION_AVAILABLE_PROPERTY;
+import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.PRODUCT_ID_PROPERTY;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.PRODUCT_LATEST_DESCRIPTION_PROPERTY;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.PRODUCT_LATEST_RELEASE_AT_PROPERTY;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.ServerDevicesProperties.PRODUCT_LATEST_VERSION_PROPERTY;
@@ -217,6 +219,35 @@ class ServerSuplaDeviceHandlerTest {
                 .doesNotContainKey(SOFTWARE_UPDATE_VERSION_PROPERTY)
                 .doesNotContainKey(SOFTWARE_UPDATE_URL_PROPERTY);
         assertThat(properties.get(SOFTWARE_UPDATE_LAST_CHECK_PROPERTY)).isEqualTo(checkedAt.toString());
+    }
+
+    @Test
+    void shouldClearProductInfoProperties() {
+        properties.put("OTHER", "preserved");
+        properties.put(MANUFACTURER_ID_PROPERTY, "4");
+        properties.put(PRODUCT_ID_PROPERTY, "6000");
+        properties.put(PRODUCT_MANUFACTURER_PROPERTY, "Zamel");
+        properties.put(PRODUCT_NAME_PROPERTY, "THW-01");
+        properties.put(PRODUCT_UPDATES_COUNT_PROPERTY, "1");
+        properties.put(PRODUCT_LATEST_RELEASE_AT_PROPERTY, "2024-09-05");
+        properties.put(PRODUCT_LATEST_VERSION_PROPERTY, "1.0.0");
+        properties.put(PRODUCT_LATEST_DESCRIPTION_PROPERTY, "desc");
+        properties.put(PRODUCT_URL_PROPERTY, "https://example.org");
+
+        handler.clearProductInfoProperties();
+
+        assertThat(properties)
+                .containsEntry("OTHER", "preserved")
+                .doesNotContainKeys(
+                        MANUFACTURER_ID_PROPERTY,
+                        PRODUCT_ID_PROPERTY,
+                        PRODUCT_MANUFACTURER_PROPERTY,
+                        PRODUCT_NAME_PROPERTY,
+                        PRODUCT_UPDATES_COUNT_PROPERTY,
+                        PRODUCT_LATEST_RELEASE_AT_PROPERTY,
+                        PRODUCT_LATEST_VERSION_PROPERTY,
+                        PRODUCT_LATEST_DESCRIPTION_PROPERTY,
+                        PRODUCT_URL_PROPERTY);
     }
 
     @Test


### PR DESCRIPTION
### Motivation

- Previously product-related thing properties (manufacturer/product/catalog fields) were only set when product info was available and were not cleared when a device re-registered with missing/unknown IDs or when optional catalog fields disappeared, leaving stale values persisted on the thing. 
- `register(...)` already clears other dynamic groups (device config, channel properties) so product-info keys need the same explicit cleanup to keep thing properties accurate.

### Description

- Added a `PRODUCT_INFO_PROPERTIES` constant set containing manufacturer/product IDs and all product-catalog property keys. 
- Added `clearProductInfoProperties()` which clears only the product-related properties and uses `.toList()` before mutation to avoid concurrent modification. 
- Invoke `clearProductInfoProperties()` at the start of the property update section inside `register(...)` so stale values are removed before writing new ones. 
- Added a unit test `shouldClearProductInfoProperties()` to verify product keys are removed while unrelated properties remain, and updated test imports to include the new constants.

### Testing

- Ran `mvn spotless:apply` which completed successfully. 
- Ran `mvn test`; an initial run surfaced a `ConcurrentModification` error which was fixed by materializing the key list, and a subsequent `mvn test` run completed successfully with `Tests run: 208, Failures: 0, Errors: 0, Skipped: 0`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0be69690c8320b1a0aa64016d4b3c)