### PR TITLE
Fix software update status checks

### DIFF
--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/updates/SuplaUpdatesClient.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/updates/SuplaUpdatesClient.java
@@ -14,6 +14,9 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -205,7 +208,7 @@ public class SuplaUpdatesClient {
     private static @Nullable Result inferResultFromUpdates(Request request, List<UpdateEntry> updates) {
         var latestUpdate = updates.stream()
                 .filter(UpdateEntry::isDefaultUpdate)
-                .findFirst()
+                .max(SuplaUpdatesClient::compareUpdates)
                 .orElse(null);
         if (latestUpdate == null) {
             return null;
@@ -214,7 +217,7 @@ public class SuplaUpdatesClient {
         if (latestVersion == null) {
             return null;
         }
-        if (sameVersion(request.version(), latestVersion)) {
+        if (request.version() != null && compareVersions(latestVersion, request.version()) <= 0) {
             return new Result(Status.UPDATE_NOT_AVAILABLE, null, null);
         }
         return new Result(Status.UPDATE_AVAILABLE, latestVersion, emptyToNull(latestUpdate.updateUrl));
@@ -224,6 +227,84 @@ public class SuplaUpdatesClient {
         var firstVersion = emptyToNull(first);
         var secondVersion = emptyToNull(second);
         return firstVersion != null && firstVersion.equals(secondVersion);
+    }
+
+    private static int compareUpdates(UpdateEntry first, UpdateEntry second) {
+        var releaseDateComparison =
+                compareNullableInstants(parseInstant(first.releasedAt), parseInstant(second.releasedAt));
+        if (releaseDateComparison != 0) {
+            return releaseDateComparison;
+        }
+        return compareVersions(first.version, second.version);
+    }
+
+    private static int compareNullableInstants(@Nullable Instant first, @Nullable Instant second) {
+        if (first == null && second == null) {
+            return 0;
+        }
+        if (first == null) {
+            return -1;
+        }
+        if (second == null) {
+            return 1;
+        }
+        return first.compareTo(second);
+    }
+
+    private static @Nullable Instant parseInstant(@Nullable String value) {
+        var instant = emptyToNull(value);
+        if (instant == null) {
+            return null;
+        }
+        try {
+            return OffsetDateTime.parse(instant).toInstant();
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+    }
+
+    private static int compareVersions(@Nullable String first, @Nullable String second) {
+        var firstVersion = emptyToNull(first);
+        var secondVersion = emptyToNull(second);
+        if (firstVersion == null && secondVersion == null) {
+            return 0;
+        }
+        if (firstVersion == null) {
+            return -1;
+        }
+        if (secondVersion == null) {
+            return 1;
+        }
+        var firstParts = firstVersion.split("[._-]");
+        var secondParts = secondVersion.split("[._-]");
+        var maxLength = Math.max(firstParts.length, secondParts.length);
+        for (var i = 0; i < maxLength; i++) {
+            var firstPart = i < firstParts.length ? firstParts[i] : "0";
+            var secondPart = i < secondParts.length ? secondParts[i] : "0";
+            var comparison = compareVersionParts(firstPart, secondPart);
+            if (comparison != 0) {
+                return comparison;
+            }
+        }
+        return 0;
+    }
+
+    private static int compareVersionParts(String first, String second) {
+        if (first.chars().allMatch(Character::isDigit) && second.chars().allMatch(Character::isDigit)) {
+            var normalizedFirst = removeLeadingZeroes(first);
+            var normalizedSecond = removeLeadingZeroes(second);
+            var lengthComparison = Integer.compare(normalizedFirst.length(), normalizedSecond.length());
+            if (lengthComparison != 0) {
+                return lengthComparison;
+            }
+            return normalizedFirst.compareTo(normalizedSecond);
+        }
+        return first.compareToIgnoreCase(second);
+    }
+
+    private static String removeLeadingZeroes(String value) {
+        var stripped = value.replaceFirst("^0+", "");
+        return stripped.isEmpty() ? "0" : stripped;
     }
 
     private static @Nullable String emptyToNull(@Nullable String value) {
@@ -351,6 +432,9 @@ public class SuplaUpdatesClient {
 
         @Nullable
         String updateUrl;
+
+        @Nullable
+        String releasedAt;
 
         @Nullable
         Integer platform;

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/updates/SuplaUpdatesClient.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/updates/SuplaUpdatesClient.java
@@ -7,13 +7,16 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toUnmodifiableMap;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.StringJoiner;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -22,9 +25,11 @@ import org.eclipse.jdt.annotation.Nullable;
 public class SuplaUpdatesClient {
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
     private static final URI CHECK_UPDATES_URI = URI.create("https://updates.supla.org/check-updates");
+    private static final URI LIST_UPDATES_URI = URI.create("https://updates.supla.org/list-updates");
 
     private final HttpClient httpClient;
     private final URI checkUpdatesUri;
+    private final URI listUpdatesUri;
     private final Gson gson = new Gson();
 
     public SuplaUpdatesClient() {
@@ -33,24 +38,79 @@ public class SuplaUpdatesClient {
                         .connectTimeout(REQUEST_TIMEOUT)
                         .followRedirects(HttpClient.Redirect.NORMAL)
                         .build(),
-                CHECK_UPDATES_URI);
+                CHECK_UPDATES_URI,
+                LIST_UPDATES_URI);
     }
 
     SuplaUpdatesClient(HttpClient httpClient, URI checkUpdatesUri) {
+        this(httpClient, checkUpdatesUri, LIST_UPDATES_URI);
+    }
+
+    SuplaUpdatesClient(HttpClient httpClient, URI checkUpdatesUri, URI listUpdatesUri) {
         this.httpClient = httpClient;
         this.checkUpdatesUri = checkUpdatesUri;
+        this.listUpdatesUri = listUpdatesUri;
     }
 
     public Result checkUpdates(Request request) throws IOException, InterruptedException {
+        var updates = request.hasUpdateFilter() ? List.<UpdateEntry>of() : listUpdatesOrEmpty(request);
+        var enrichedRequest = discoverUpdateFilter(request, updates);
+        var requestToCheck = enrichedRequest == null ? request : request.withFilter(enrichedRequest);
+        try {
+            var result = executeCheckUpdates(requestToCheck);
+            if (result.status() != Status.UNKNOWN_PRODUCT) {
+                return result;
+            }
+            var fallbackResult = inferResultFromUpdates(request, updates);
+            return fallbackResult == null ? result : fallbackResult;
+        } catch (IOException exception) {
+            var fallbackResult = inferResultFromUpdates(request, updates);
+            if (fallbackResult != null) {
+                return fallbackResult;
+            }
+            throw exception;
+        }
+    }
+
+    private Result executeCheckUpdates(Request request) throws IOException, InterruptedException {
         var httpRequest = HttpRequest.newBuilder(buildUri(checkUpdatesUri, request))
                 .timeout(REQUEST_TIMEOUT)
                 .GET()
                 .build();
         var response = httpClient.send(httpRequest, BodyHandlers.ofString(UTF_8));
+        var responseBody = response.body();
         if (response.statusCode() != 200) {
+            var parsedResponse = tryParseResponse(responseBody);
+            if (parsedResponse != null) {
+                return parsedResponse;
+            }
             throw new IOException("Unexpected update check response status " + response.statusCode());
         }
-        return parseResponse(response.body());
+        return parseResponse(responseBody);
+    }
+
+    private List<UpdateEntry> listUpdatesOrEmpty(Request request) throws IOException, InterruptedException {
+        try {
+            return listUpdates(request);
+        } catch (IOException | JsonSyntaxException e) {
+            return List.of();
+        }
+    }
+
+    private List<UpdateEntry> listUpdates(Request request) throws IOException, InterruptedException {
+        var httpRequest = HttpRequest.newBuilder(buildListUri(listUpdatesUri, request))
+                .timeout(REQUEST_TIMEOUT)
+                .GET()
+                .build();
+        var response = httpClient.send(httpRequest, BodyHandlers.ofString(UTF_8));
+        if (response.statusCode() != 200) {
+            throw new IOException("Unexpected update list response status " + response.statusCode());
+        }
+        var updates = gson.fromJson(response.body(), UpdateEntry[].class);
+        if (updates == null) {
+            return List.of();
+        }
+        return stream(updates).filter(Objects::nonNull).toList();
     }
 
     static URI buildUri(URI baseUri, Request request) {
@@ -61,6 +121,23 @@ public class SuplaUpdatesClient {
         if (request.version() != null && !request.version().isBlank()) {
             addQueryParam(query, "version", request.version());
         }
+        addOptionalQueryParam(query, "platform", request.platform());
+        addOptionalQueryParam(query, "param1", request.param1());
+        addOptionalQueryParam(query, "param2", request.param2());
+        addOptionalQueryParam(query, "param3", request.param3());
+        addOptionalQueryParam(query, "param4", request.param4());
+
+        var base = baseUri.toString();
+        var separator = base.contains("?") ? "&" : "?";
+        return URI.create(base + separator + query);
+    }
+
+    static URI buildListUri(URI baseUri, Request request) {
+        var query = new StringJoiner("&");
+        addQueryParam(query, "manufacturerId", Integer.toString(request.manufacturerId()));
+        addQueryParam(query, "productId", Integer.toString(request.productId()));
+        addQueryParam(query, "productName", request.productName());
+        addQueryParam(query, "ignoreUpdateFilters", Boolean.TRUE.toString());
 
         var base = baseUri.toString();
         var separator = base.contains("?") ? "&" : "?";
@@ -80,24 +157,115 @@ public class SuplaUpdatesClient {
                 latestUpdate == null ? null : emptyToNull(latestUpdate.updateUrl));
     }
 
+    private @Nullable Result tryParseResponse(String responseBody) {
+        try {
+            return parseResponse(responseBody);
+        } catch (IOException | JsonSyntaxException e) {
+            return null;
+        }
+    }
+
     private static void addQueryParam(StringJoiner query, String name, String value) {
         query.add(encode(name, UTF_8) + "=" + encode(value, UTF_8));
+    }
+
+    private static void addOptionalQueryParam(StringJoiner query, String name, @Nullable Integer value) {
+        if (value != null) {
+            addQueryParam(query, name, value.toString());
+        }
+    }
+
+    private static @Nullable UpdateFilter discoverUpdateFilter(Request request, List<UpdateEntry> updates) {
+        if (updates.isEmpty()) {
+            return null;
+        }
+        var matchingCurrentVersion = updates.stream()
+                .filter(update -> sameVersion(request.version(), update.version))
+                .toList();
+        var candidates = matchingCurrentVersion.isEmpty() ? updates : matchingCurrentVersion;
+        var filters = candidates.stream()
+                .map(UpdateFilter::fromUpdate)
+                .filter(UpdateFilter::hasAny)
+                .distinct()
+                .toList();
+        if (filters.size() == 1) {
+            return filters.getFirst();
+        }
+        var platforms = candidates.stream()
+                .map(update -> update.platform)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        if (platforms.size() == 1) {
+            return new UpdateFilter(platforms.getFirst(), null, null, null, null);
+        }
+        return null;
+    }
+
+    private static @Nullable Result inferResultFromUpdates(Request request, List<UpdateEntry> updates) {
+        var latestUpdate = updates.stream()
+                .filter(UpdateEntry::isDefaultUpdate)
+                .findFirst()
+                .orElse(null);
+        if (latestUpdate == null) {
+            return null;
+        }
+        var latestVersion = emptyToNull(latestUpdate.version);
+        if (latestVersion == null) {
+            return null;
+        }
+        if (sameVersion(request.version(), latestVersion)) {
+            return new Result(Status.UPDATE_NOT_AVAILABLE, null, null);
+        }
+        return new Result(Status.UPDATE_AVAILABLE, latestVersion, emptyToNull(latestUpdate.updateUrl));
+    }
+
+    private static boolean sameVersion(@Nullable String first, @Nullable String second) {
+        var firstVersion = emptyToNull(first);
+        var secondVersion = emptyToNull(second);
+        return firstVersion != null && firstVersion.equals(secondVersion);
     }
 
     private static @Nullable String emptyToNull(@Nullable String value) {
         if (value == null || value.isBlank()) {
             return null;
         }
-        return value;
+        return value.trim();
     }
 
     public record Request(
             int manufacturerId,
             int productId,
             String productName,
-            @Nullable String version) {
+            @Nullable String version,
+            @Nullable Integer platform,
+            @Nullable Integer param1,
+            @Nullable Integer param2,
+            @Nullable Integer param3,
+            @Nullable Integer param4) {
+        public Request(int manufacturerId, int productId, String productName, @Nullable String version) {
+            this(manufacturerId, productId, productName, version, null, null, null, null, null);
+        }
+
         public Request {
             requireNonNull(productName);
+        }
+
+        boolean hasUpdateFilter() {
+            return platform != null || param1 != null || param2 != null || param3 != null || param4 != null;
+        }
+
+        Request withFilter(UpdateFilter filter) {
+            return new Request(
+                    manufacturerId,
+                    productId,
+                    productName,
+                    version,
+                    filter.platform(),
+                    filter.param1(),
+                    filter.param2(),
+                    filter.param3(),
+                    filter.param4());
         }
     }
 
@@ -152,6 +320,21 @@ public class SuplaUpdatesClient {
         }
     }
 
+    private record UpdateFilter(
+            @Nullable Integer platform,
+            @Nullable Integer param1,
+            @Nullable Integer param2,
+            @Nullable Integer param3,
+            @Nullable Integer param4) {
+        static UpdateFilter fromUpdate(UpdateEntry update) {
+            return new UpdateFilter(update.platform, update.param1, update.param2, update.param3, update.param4);
+        }
+
+        boolean hasAny() {
+            return platform != null || param1 != null || param2 != null || param3 != null || param4 != null;
+        }
+    }
+
     @SuppressWarnings("MemberName")
     private static class Response {
         @Nullable
@@ -168,5 +351,35 @@ public class SuplaUpdatesClient {
 
         @Nullable
         String updateUrl;
+
+        @Nullable
+        Integer platform;
+
+        @Nullable
+        Integer param1;
+
+        @Nullable
+        Integer param2;
+
+        @Nullable
+        Integer param3;
+
+        @Nullable
+        Integer param4;
+
+        @Nullable
+        Boolean isBeta;
+
+        @Nullable
+        Boolean hiddenInFrontend;
+
+        @Nullable
+        Boolean otaTest;
+
+        boolean isDefaultUpdate() {
+            return !Boolean.TRUE.equals(isBeta)
+                    && !Boolean.TRUE.equals(hiddenInFrontend)
+                    && !Boolean.TRUE.equals(otaTest);
+        }
     }
 }

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/updates/SuplaUpdatesClientTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/updates/SuplaUpdatesClientTest.java
@@ -154,6 +154,7 @@ class SuplaUpdatesClientTest {
                         [
                           {
                             "version": "2.8.61",
+                            "releasedAt": "2024-07-23T09:52:50+00:00",
                             "platform": 1,
                             "param1": 5,
                             "param2": 1,
@@ -161,6 +162,7 @@ class SuplaUpdatesClientTest {
                           },
                           {
                             "version": "2.8.61",
+                            "releasedAt": "2024-07-23T09:52:50+00:00",
                             "platform": 1,
                             "param1": 5,
                             "param2": 0,
@@ -174,6 +176,50 @@ class SuplaUpdatesClientTest {
         assertThat(result.status()).isEqualTo(SuplaUpdatesClient.Status.UPDATE_AVAILABLE);
         assertThat(result.latestVersion()).isEqualTo("2.8.61");
         assertThat(result.updateUrl()).isEqualTo("https://updates.example/user1");
+    }
+
+    @Test
+    void shouldInferNewestListedUpdateWhenUpdatesAreNotOrdered() throws Exception {
+        givenResponses(response(200, """
+                        [
+                          {
+                            "version": "2.8.61",
+                            "releasedAt": "2024-07-23T09:52:50+00:00",
+                            "updateUrl": "https://updates.example/older"
+                          },
+                          {
+                            "version": "2.8.62",
+                            "releasedAt": "2025-03-03T16:35:59+00:00",
+                            "updateUrl": "https://updates.example/newer"
+                          }
+                        ]
+                        """), response(404, "{\"status\":\"Unknown product\"}"));
+
+        var result = client.checkUpdates(new SuplaUpdatesClient.Request(0, 0, "ZAMEL mSRW-01", "2.8.61"));
+
+        assertThat(result.status()).isEqualTo(SuplaUpdatesClient.Status.UPDATE_AVAILABLE);
+        assertThat(result.latestVersion()).isEqualTo("2.8.62");
+        assertThat(result.updateUrl()).isEqualTo("https://updates.example/newer");
+    }
+
+    @Test
+    void shouldNotInferDowngradeFromListedUpdates() throws Exception {
+        givenResponses(response(200, """
+                        [
+                          {
+                            "version": "2.8.61",
+                            "releasedAt": "2024-07-23T09:52:50+00:00",
+                            "updateUrl": "https://updates.example/older"
+                          }
+                        ]
+                        """), response(404, "{\"status\":\"Unknown product\"}"));
+
+        var result = client.checkUpdates(new SuplaUpdatesClient.Request(0, 0, "ZAMEL MEW-01", "2.8.62"));
+
+        assertThat(result.status()).isEqualTo(SuplaUpdatesClient.Status.UPDATE_NOT_AVAILABLE);
+        assertThat(result.updateAvailable()).isFalse();
+        assertThat(result.latestVersion()).isNull();
+        assertThat(result.updateUrl()).isNull();
     }
 
     private void givenResponses(HttpResponse<String> first, HttpResponse<String>... rest)

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/updates/SuplaUpdatesClientTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/updates/SuplaUpdatesClientTest.java
@@ -2,13 +2,35 @@ package pl.grzeslowski.openhab.supla.internal.updates;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class SuplaUpdatesClientTest {
-    private final SuplaUpdatesClient client = new SuplaUpdatesClient();
+    private HttpClient httpClient;
+    private SuplaUpdatesClient client;
+
+    @BeforeEach
+    void setUp() {
+        httpClient = mock(HttpClient.class);
+        client = new SuplaUpdatesClient(
+                httpClient,
+                URI.create("https://updates.supla.org/check-updates"),
+                URI.create("https://updates.supla.org/list-updates"));
+    }
 
     @Test
     void shouldBuildCheckUpdatesUri() {
@@ -30,6 +52,28 @@ class SuplaUpdatesClientTest {
         assertThat(uri.toString())
                 .isEqualTo(
                         "https://updates.supla.org/check-updates?manufacturerId=4&productId=6000&productName=ZAMEL+THW-01");
+    }
+
+    @Test
+    void shouldBuildCheckUpdatesUriWithUpdateFilters() {
+        var uri = SuplaUpdatesClient.buildUri(
+                URI.create("https://updates.supla.org/check-updates"),
+                new SuplaUpdatesClient.Request(4, 6000, "ZAMEL THW-01", "23.12.01", 2, 0, 1, 0, 0));
+
+        assertThat(uri.toString())
+                .isEqualTo(
+                        "https://updates.supla.org/check-updates?manufacturerId=4&productId=6000&productName=ZAMEL+THW-01&version=23.12.01&platform=2&param1=0&param2=1&param3=0&param4=0");
+    }
+
+    @Test
+    void shouldBuildListUpdatesUri() {
+        var uri = SuplaUpdatesClient.buildListUri(
+                URI.create("https://updates.supla.org/list-updates"),
+                new SuplaUpdatesClient.Request(4, 6000, "ZAMEL THW-01", "23.12.01"));
+
+        assertThat(uri.toString())
+                .isEqualTo(
+                        "https://updates.supla.org/list-updates?manufacturerId=4&productId=6000&productName=ZAMEL+THW-01&ignoreUpdateFilters=true");
     }
 
     @Test
@@ -65,5 +109,93 @@ class SuplaUpdatesClientTest {
         assertThatThrownBy(() -> client.parseResponse("{\"status\":\"Unexpected\"}"))
                 .isInstanceOf(IOException.class)
                 .hasMessageContaining("Unknown update check status");
+    }
+
+    @Test
+    void shouldParseUnknownProductEvenWhenResponseIsNotSuccessful() throws Exception {
+        givenResponses(response(404, "{\"status\":\"Unknown product\"}"));
+
+        var result = client.checkUpdates(new SuplaUpdatesClient.Request(4, 6000, "Unknown", "23.12.01"));
+
+        assertThat(result.status()).isEqualTo(SuplaUpdatesClient.Status.UNKNOWN_PRODUCT);
+        assertThat(result.updateAvailable()).isFalse();
+    }
+
+    @Test
+    void shouldDiscoverUpdateFilterBeforeCheckingUpdates() throws Exception {
+        givenResponses(response(200, """
+                        [
+                          {
+                            "version": "23.12.02",
+                            "platform": 2,
+                            "param1": 0,
+                            "param2": 0,
+                            "param3": 0,
+                            "param4": 0,
+                            "updateUrl": "https://updates.example/thw"
+                          }
+                        ]
+                        """), response(200, "{\"status\":\"Update not available\"}"));
+
+        var result = client.checkUpdates(new SuplaUpdatesClient.Request(4, 6000, "ZAMEL THW-01", "23.12.02"));
+
+        assertThat(result.status()).isEqualTo(SuplaUpdatesClient.Status.UPDATE_NOT_AVAILABLE);
+        assertThat(sentRequests().get(0).uri().toString())
+                .isEqualTo(
+                        "https://updates.supla.org/list-updates?manufacturerId=4&productId=6000&productName=ZAMEL+THW-01&ignoreUpdateFilters=true");
+        assertThat(sentRequests().get(1).uri().toString())
+                .isEqualTo(
+                        "https://updates.supla.org/check-updates?manufacturerId=4&productId=6000&productName=ZAMEL+THW-01&version=23.12.02&platform=2&param1=0&param2=0&param3=0&param4=0");
+    }
+
+    @Test
+    void shouldInferResultFromListedUpdatesWhenCheckUpdatesRejectsAmbiguousFilters() throws Exception {
+        givenResponses(response(200, """
+                        [
+                          {
+                            "version": "2.8.61",
+                            "platform": 1,
+                            "param1": 5,
+                            "param2": 1,
+                            "updateUrl": "https://updates.example/user1"
+                          },
+                          {
+                            "version": "2.8.61",
+                            "platform": 1,
+                            "param1": 5,
+                            "param2": 0,
+                            "updateUrl": "https://updates.example/user2"
+                          }
+                        ]
+                        """), response(404, "{\"status\":\"Unknown product\"}"));
+
+        var result = client.checkUpdates(new SuplaUpdatesClient.Request(0, 0, "ZAMEL MEW-01", "2.8.60"));
+
+        assertThat(result.status()).isEqualTo(SuplaUpdatesClient.Status.UPDATE_AVAILABLE);
+        assertThat(result.latestVersion()).isEqualTo("2.8.61");
+        assertThat(result.updateUrl()).isEqualTo("https://updates.example/user1");
+    }
+
+    private void givenResponses(HttpResponse<String> first, HttpResponse<String>... rest)
+            throws IOException, InterruptedException {
+        when(httpClient.send(any(HttpRequest.class), anyStringBodyHandler())).thenReturn(first, rest);
+    }
+
+    private List<HttpRequest> sentRequests() throws IOException, InterruptedException {
+        var requests = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(httpClient, times(2)).send(requests.capture(), anyStringBodyHandler());
+        return requests.getAllValues();
+    }
+
+    private static BodyHandler<String> anyStringBodyHandler() {
+        return any();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static HttpResponse<String> response(int statusCode, String body) {
+        var response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(statusCode);
+        when(response.body()).thenReturn(body);
+        return response;
     }
 }


### PR DESCRIPTION
## Summary
- discover SUPLA update filters via /list-updates before /check-updates
- parse known update statuses from non-200 API responses
- fall back to listed updates when filters are ambiguous

## Tests
- mvn -Dtest=SuplaUpdatesClientTest test
- mvn test