### PR TITLE
Make server device handlers timezone-aware using TimeZoneProvider

### DIFF
--- a/src/integration-test/java/pl/grzeslowski/openhab/supla/internal/extension/supla/SuplaExtension.java
+++ b/src/integration-test/java/pl/grzeslowski/openhab/supla/internal/extension/supla/SuplaExtension.java
@@ -10,6 +10,7 @@ import static org.openhab.core.thing.ThingStatusDetail.HANDLER_CONFIGURATION_PEN
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.SUPLA_SERVER_TYPE;
 import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.SUPPORTED_THING_TYPES_UIDS;
 
+import java.time.ZoneId;
 import java.util.*;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.MultiValuedMap;
@@ -17,6 +18,7 @@ import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 import org.eclipse.jdt.annotation.Nullable;
 import org.junit.jupiter.api.extension.*;
 import org.openhab.core.config.core.Configuration;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.thing.ThingStatusInfo;
 import org.openhab.core.thing.ThingTypeUID;
 import org.openhab.core.thing.binding.BridgeHandler;
@@ -33,7 +35,9 @@ import pl.grzeslowski.openhab.supla.internal.server.oh_config.TimeoutConfigurati
 @SuppressWarnings("StaticMethodOnlyUsedInOneClass")
 @Slf4j
 public class SuplaExtension implements BeforeEachCallback, AfterEachCallback, ParameterResolver {
-    private final SuplaHandlerFactory factory = new SuplaHandlerFactory();
+    private static final TimeZoneProvider TIME_ZONE_PROVIDER = () -> ZoneId.of("America/New_York");
+
+    private final SuplaHandlerFactory factory = new SuplaHandlerFactory(TIME_ZONE_PROVIDER);
     private final MultiValuedMap<String, ThingHandler> handlers = new ArrayListValuedHashMap<>();
 
     @Override

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/SuplaHandlerFactory.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/SuplaHandlerFactory.java
@@ -42,6 +42,12 @@ public class SuplaHandlerFactory extends BaseThingHandlerFactory implements Serv
     @Reference
     private TimeZoneProvider timeZoneProvider;
 
+    public SuplaHandlerFactory() {}
+
+    public SuplaHandlerFactory(TimeZoneProvider timeZoneProvider) {
+        this.timeZoneProvider = timeZoneProvider;
+    }
+
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
         return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
@@ -95,7 +101,7 @@ public class SuplaHandlerFactory extends BaseThingHandlerFactory implements Serv
 
     @NonNull
     private ThingHandler newServerDeviceHandler(final Thing thing) {
-        return new SingleDeviceHandler(thing, this, timeZoneProvider);
+        return new SingleDeviceHandler(thing, this, timeZoneProvider());
     }
 
     @NonNull
@@ -139,7 +145,7 @@ public class SuplaHandlerFactory extends BaseThingHandlerFactory implements Serv
 
     private ThingHandler newGatewayDeviceHandler(Thing thing) {
         var discovery = new ServerDiscoveryService(thing.getUID());
-        var bridgeHandler = new GatewayDeviceHandler(thing, discovery, this, timeZoneProvider);
+        var bridgeHandler = new GatewayDeviceHandler(thing, discovery, this, timeZoneProvider());
         var serviceRegistration = registerThingDiscovery(discovery);
         servicesToDispose.put(bridgeHandler, serviceRegistration.getReference());
         return bridgeHandler;
@@ -147,6 +153,10 @@ public class SuplaHandlerFactory extends BaseThingHandlerFactory implements Serv
 
     private ThingHandler newSubDeviceHandler(Thing thing) {
         return new SubDeviceHandler(thing);
+    }
+
+    private TimeZoneProvider timeZoneProvider() {
+        return Objects.requireNonNull(timeZoneProvider, "timeZoneProvider");
     }
 
     @Override

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/SuplaHandlerFactory.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/SuplaHandlerFactory.java
@@ -9,6 +9,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.config.discovery.DiscoveryService;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingTypeUID;
@@ -21,6 +22,7 @@ import org.openhab.core.thing.binding.ThingHandlerFactory;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.grzeslowski.openhab.supla.internal.cloud.discovery.CloudDiscovery;
@@ -36,6 +38,9 @@ public class SuplaHandlerFactory extends BaseThingHandlerFactory implements Serv
     private final Logger logger = LoggerFactory.getLogger(SuplaHandlerFactory.class);
     private final Map<BridgeHandler, ServiceReference<?>> servicesToDispose = synchronizedMap(new HashMap<>());
     private final Map<ThingUID, ActionServiceRegistrations> actionServicesToDispose = synchronizedMap(new HashMap<>());
+
+    @Reference
+    private TimeZoneProvider timeZoneProvider;
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -90,7 +95,7 @@ public class SuplaHandlerFactory extends BaseThingHandlerFactory implements Serv
 
     @NonNull
     private ThingHandler newServerDeviceHandler(final Thing thing) {
-        return new SingleDeviceHandler(thing, this);
+        return new SingleDeviceHandler(thing, this, timeZoneProvider);
     }
 
     @NonNull
@@ -134,7 +139,7 @@ public class SuplaHandlerFactory extends BaseThingHandlerFactory implements Serv
 
     private ThingHandler newGatewayDeviceHandler(Thing thing) {
         var discovery = new ServerDiscoveryService(thing.getUID());
-        var bridgeHandler = new GatewayDeviceHandler(thing, discovery, this);
+        var bridgeHandler = new GatewayDeviceHandler(thing, discovery, this, timeZoneProvider);
         var serviceRegistration = registerThingDiscovery(discovery);
         servicesToDispose.put(bridgeHandler, serviceRegistration.getReference());
         return bridgeHandler;

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/GatewayDeviceHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/GatewayDeviceHandler.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.ThreadPoolManager;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.library.types.*;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
@@ -71,8 +72,9 @@ public class GatewayDeviceHandler extends ServerSuplaDeviceHandler implements Se
     public GatewayDeviceHandler(
             Thing thing,
             ServerDiscoveryService serverDiscoveryService,
-            ServerDeviceActionServiceRegistry actionServiceRegistry) {
-        super(thing, actionServiceRegistry);
+            ServerDeviceActionServiceRegistry actionServiceRegistry,
+            TimeZoneProvider timeZoneProvider) {
+        super(thing, actionServiceRegistry, timeZoneProvider);
         this.serverDiscoveryService = serverDiscoveryService;
     }
 

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandler.java
@@ -1070,11 +1070,6 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
     }
 
     static Map<String, String> buildProductInfoProperties(
-            @Nullable Integer manufacturerId, @Nullable Integer productId) {
-        return buildProductInfoProperties(manufacturerId, productId, ZoneId::systemDefault);
-    }
-
-    static Map<String, String> buildProductInfoProperties(
             @Nullable Integer manufacturerId, @Nullable Integer productId, TimeZoneProvider timeZoneProvider) {
         if (manufacturerId == null || productId == null) {
             return Map.of();

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandler.java
@@ -36,6 +36,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.time.format.TextStyle;
 import java.util.*;
 import java.util.concurrent.Future;
@@ -51,6 +52,7 @@ import lombok.experimental.Delegate;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.common.ThreadPoolManager;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
@@ -130,6 +132,7 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
     private final long id = ID.incrementAndGet();
     private final ServerDeviceActionServiceRegistry actionServiceRegistry;
     private final SuplaUpdatesClient updatesClient;
+    private final TimeZoneProvider timeZoneProvider;
 
     @Getter
     protected Logger logger = LoggerFactory.getLogger(baseLogger());
@@ -196,15 +199,20 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
         UPDATE_TRIGGERED
     }
 
-    public ServerSuplaDeviceHandler(Thing thing, ServerDeviceActionServiceRegistry actionServiceRegistry) {
-        this(thing, actionServiceRegistry, new SuplaUpdatesClient());
+    public ServerSuplaDeviceHandler(
+            Thing thing, ServerDeviceActionServiceRegistry actionServiceRegistry, TimeZoneProvider timeZoneProvider) {
+        this(thing, actionServiceRegistry, new SuplaUpdatesClient(), timeZoneProvider);
     }
 
     ServerSuplaDeviceHandler(
-            Thing thing, ServerDeviceActionServiceRegistry actionServiceRegistry, SuplaUpdatesClient updatesClient) {
+            Thing thing,
+            ServerDeviceActionServiceRegistry actionServiceRegistry,
+            SuplaUpdatesClient updatesClient,
+            TimeZoneProvider timeZoneProvider) {
         super(thing);
         this.actionServiceRegistry = actionServiceRegistry;
         this.updatesClient = updatesClient;
+        this.timeZoneProvider = timeZoneProvider;
     }
 
     @Override
@@ -431,7 +439,7 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
             if (registerEntity.productId() != null) {
                 thing.setProperty(PRODUCT_ID_PROPERTY, valueOf(registerEntity.productId()));
             }
-            buildProductInfoProperties(registerEntity.manufacturerId(), registerEntity.productId())
+            buildProductInfoProperties(registerEntity.manufacturerId(), registerEntity.productId(), timeZoneProvider)
                     .forEach(thing::setProperty);
         }
 
@@ -523,7 +531,7 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
         var seconds = (short) now.getSecond();
 
         // Get the system's default time zone
-        var zoneId = ZoneId.systemDefault();
+        var zoneId = timeZoneProvider.getTimeZone();
         var timeZoneName = zoneId.getDisplayName(TextStyle.SHORT, Locale.getDefault());
         var timeZone = timeZoneName.getBytes(); // Convert to byte array
         var timeZoneSize = timeZone.length;
@@ -539,7 +547,9 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
             var millis =
                     SECONDS.toMillis(response.now().tvSec()) + response.now().tvUsec();
             var formatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSS z");
-            var date = Instant.ofEpochMilli(millis).atZone(ZoneId.of("UTC")).withZoneSameLocal(ZoneId.systemDefault());
+            var date = Instant.ofEpochMilli(millis)
+                    .atZone(ZoneId.of("UTC"))
+                    .withZoneSameLocal(timeZoneProvider.getTimeZone());
             logger.trace(
                     "pingServer {} ({}s {}ms)",
                     formatter.format(date),
@@ -979,7 +989,9 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
         setProperty(SOFTWARE_UPDATE_URL_PROPERTY, result.updateAvailable() ? emptyToNull(result.updateUrl()) : null);
         setProperty(
                 SOFTWARE_UPDATE_LAST_CHECK_PROPERTY,
-                Optional.ofNullable(checkedAt).map(Instant::toString).orElse(null));
+                Optional.ofNullable(checkedAt)
+                        .map(this::toOpenHabTimezoneDateTime)
+                        .orElse(null));
     }
 
     private void clearSoftwareUpdateState() {
@@ -1060,6 +1072,11 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
 
     static Map<String, String> buildProductInfoProperties(
             @Nullable Integer manufacturerId, @Nullable Integer productId) {
+        return buildProductInfoProperties(manufacturerId, productId, ZoneId::systemDefault);
+    }
+
+    static Map<String, String> buildProductInfoProperties(
+            @Nullable Integer manufacturerId, @Nullable Integer productId, TimeZoneProvider timeZoneProvider) {
         if (manufacturerId == null || productId == null) {
             return Map.of();
         }
@@ -1070,7 +1087,9 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
                     putProductInfoProperty(properties, PRODUCT_NAME_PROPERTY, productInfo.name());
                     properties.put(PRODUCT_UPDATES_COUNT_PROPERTY, valueOf(productInfo.updatesCount()));
                     putProductInfoProperty(
-                            properties, PRODUCT_LATEST_RELEASE_AT_PROPERTY, productInfo.latestReleaseAt());
+                            properties,
+                            PRODUCT_LATEST_RELEASE_AT_PROPERTY,
+                            toOpenHabTimezoneDateTime(productInfo.latestReleaseAt(), timeZoneProvider));
                     putProductInfoProperty(properties, PRODUCT_LATEST_VERSION_PROPERTY, productInfo.latestVersion());
                     putProductInfoProperty(
                             properties, PRODUCT_LATEST_DESCRIPTION_PROPERTY, productInfo.latestDescription());
@@ -1085,6 +1104,25 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
         var valueToSet = emptyToNull(value);
         if (valueToSet != null) {
             properties.put(property, valueToSet);
+        }
+    }
+
+    private String toOpenHabTimezoneDateTime(Instant instant) {
+        return instant.atZone(timeZoneProvider.getTimeZone()).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    }
+
+    private static @Nullable String toOpenHabTimezoneDateTime(
+            @Nullable String dateTime, TimeZoneProvider timeZoneProvider) {
+        var value = emptyToNull(dateTime);
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Instant.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(value))
+                    .atZone(timeZoneProvider.getTimeZone())
+                    .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        } catch (DateTimeParseException e) {
+            return value;
         }
     }
 

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandler.java
@@ -517,8 +517,9 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
     }
 
     public final void consumeLocalTimeRequest(SuplaWriter writer) {
-        // Get current local date and time
-        var now = LocalDateTime.now();
+        var zoneId = timeZoneProvider.getTimeZone();
+        // Get current local date and time in OpenHAB configured timezone
+        var now = LocalDateTime.now(zoneId);
 
         // Extract year, month, day, etc.
         var year = now.getYear();
@@ -530,8 +531,6 @@ public abstract class ServerSuplaDeviceHandler extends SuplaDeviceHandler
         var minute = (short) now.getMinute();
         var seconds = (short) now.getSecond();
 
-        // Get the system's default time zone
-        var zoneId = timeZoneProvider.getTimeZone();
         var timeZoneName = zoneId.getDisplayName(TextStyle.SHORT, Locale.getDefault());
         var timeZone = timeZoneName.getBytes(); // Convert to byte array
         var timeZoneSize = timeZone.length;

--- a/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/SingleDeviceHandler.java
+++ b/src/main/java/pl/grzeslowski/openhab/supla/internal/server/handler/SingleDeviceHandler.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 import lombok.experimental.Delegate;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.thing.Thing;
 import pl.grzeslowski.jsupla.protocol.api.ChannelType;
 import pl.grzeslowski.jsupla.protocol.api.structs.dcs.SetCaption;
@@ -41,8 +42,9 @@ public class SingleDeviceHandler extends ServerSuplaDeviceHandler {
     @Delegate(types = HandleCommand.class)
     private final HandlerCommandTrait handlerCommandTrait = new HandlerCommandTrait(this);
 
-    public SingleDeviceHandler(Thing thing, ServerDeviceActionServiceRegistry actionServiceRegistry) {
-        super(thing, actionServiceRegistry);
+    public SingleDeviceHandler(
+            Thing thing, ServerDeviceActionServiceRegistry actionServiceRegistry, TimeZoneProvider timeZoneProvider) {
+        super(thing, actionServiceRegistry, timeZoneProvider);
     }
 
     @Override

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandlerTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandlerTest.java
@@ -36,6 +36,8 @@ import static pl.grzeslowski.openhab.supla.internal.SuplaBindingConstants.Server
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -144,7 +146,11 @@ class ServerSuplaDeviceHandlerTest {
                 .containsEntry(PRODUCT_MANUFACTURER_PROPERTY, productInfo.manufacturer())
                 .containsEntry(PRODUCT_NAME_PROPERTY, productInfo.name())
                 .containsEntry(PRODUCT_UPDATES_COUNT_PROPERTY, Integer.toString(productInfo.updatesCount()))
-                .containsEntry(PRODUCT_LATEST_RELEASE_AT_PROPERTY, productInfo.latestReleaseAt())
+                .containsEntry(
+                        PRODUCT_LATEST_RELEASE_AT_PROPERTY,
+                        Instant.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(productInfo.latestReleaseAt()))
+                                .atZone(ZoneId.systemDefault())
+                                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
                 .containsEntry(PRODUCT_LATEST_VERSION_PROPERTY, productInfo.latestVersion())
                 .containsEntry(PRODUCT_LATEST_DESCRIPTION_PROPERTY, productInfo.latestDescription())
                 .containsEntry(PRODUCT_URL_PROPERTY, productInfo.productUrl());
@@ -199,7 +205,8 @@ class ServerSuplaDeviceHandlerTest {
         assertThat(properties.get(SOFTWARE_UPDATE_AVAILABLE_PROPERTY)).isEqualTo("true");
         assertThat(properties.get(SOFTWARE_UPDATE_VERSION_PROPERTY)).isEqualTo("2.0.0");
         assertThat(properties.get(SOFTWARE_UPDATE_URL_PROPERTY)).isEqualTo("https://updates.example/device");
-        assertThat(properties.get(SOFTWARE_UPDATE_LAST_CHECK_PROPERTY)).isEqualTo(checkedAt.toString());
+        assertThat(properties.get(SOFTWARE_UPDATE_LAST_CHECK_PROPERTY))
+                .isEqualTo(checkedAt.atZone(ZoneId.systemDefault()).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
     }
 
     @Test
@@ -218,7 +225,8 @@ class ServerSuplaDeviceHandlerTest {
         assertThat(properties)
                 .doesNotContainKey(SOFTWARE_UPDATE_VERSION_PROPERTY)
                 .doesNotContainKey(SOFTWARE_UPDATE_URL_PROPERTY);
-        assertThat(properties.get(SOFTWARE_UPDATE_LAST_CHECK_PROPERTY)).isEqualTo(checkedAt.toString());
+        assertThat(properties.get(SOFTWARE_UPDATE_LAST_CHECK_PROPERTY))
+                .isEqualTo(checkedAt.atZone(ZoneId.systemDefault()).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
     }
 
     @Test

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandlerTest.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/ServerSuplaDeviceHandlerTest.java
@@ -45,6 +45,7 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.thing.Thing;
 import pl.grzeslowski.jsupla.protocol.api.BitFunction;
 import pl.grzeslowski.jsupla.protocol.api.ChannelFlag;
@@ -62,6 +63,8 @@ import pl.grzeslowski.openhab.supla.internal.updates.SuplaUpdatesClient;
 
 class ServerSuplaDeviceHandlerTest {
     private static final int FIRMWARE_CHECK_MESSAGE_ID = 37;
+    private static final ZoneId TIME_ZONE = ZoneId.of("America/New_York");
+    private static final TimeZoneProvider TIME_ZONE_PROVIDER = () -> TIME_ZONE;
 
     private final Thing thing = Mockito.mock(Thing.class);
     private final Map<String, String> properties = new HashMap<>();
@@ -78,7 +81,7 @@ class ServerSuplaDeviceHandlerTest {
             }
             return properties.put(key, value);
         });
-        handler = new TestServerSuplaDeviceHandler(thing);
+        handler = new TestServerSuplaDeviceHandler(thing, TIME_ZONE_PROVIDER);
     }
 
     @Test
@@ -140,7 +143,7 @@ class ServerSuplaDeviceHandlerTest {
     void shouldBuildProductInfoPropertiesFromManufacturerAndProductIds() {
         var productInfo = SuplaProducts.findByIds(4, 6000).orElseThrow();
 
-        var properties = ServerSuplaDeviceHandler.buildProductInfoProperties(4, 6000);
+        var properties = ServerSuplaDeviceHandler.buildProductInfoProperties(4, 6000, TIME_ZONE_PROVIDER);
 
         assertThat(properties)
                 .containsEntry(PRODUCT_MANUFACTURER_PROPERTY, productInfo.manufacturer())
@@ -149,7 +152,7 @@ class ServerSuplaDeviceHandlerTest {
                 .containsEntry(
                         PRODUCT_LATEST_RELEASE_AT_PROPERTY,
                         Instant.from(DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(productInfo.latestReleaseAt()))
-                                .atZone(ZoneId.systemDefault())
+                                .atZone(TIME_ZONE)
                                 .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
                 .containsEntry(PRODUCT_LATEST_VERSION_PROPERTY, productInfo.latestVersion())
                 .containsEntry(PRODUCT_LATEST_DESCRIPTION_PROPERTY, productInfo.latestDescription())
@@ -162,10 +165,11 @@ class ServerSuplaDeviceHandlerTest {
                 .isNull();
         assertThat(ServerSuplaDeviceHandler.buildProductNameProperty(4, null)).isNull();
         assertThat(ServerSuplaDeviceHandler.buildProductNameProperty(999, 999)).isNull();
-        assertThat(ServerSuplaDeviceHandler.buildProductInfoProperties(null, 6000))
+        assertThat(ServerSuplaDeviceHandler.buildProductInfoProperties(null, 6000, TIME_ZONE_PROVIDER))
                 .isEmpty();
-        assertThat(ServerSuplaDeviceHandler.buildProductInfoProperties(4, null)).isEmpty();
-        assertThat(ServerSuplaDeviceHandler.buildProductInfoProperties(999, 999))
+        assertThat(ServerSuplaDeviceHandler.buildProductInfoProperties(4, null, TIME_ZONE_PROVIDER))
+                .isEmpty();
+        assertThat(ServerSuplaDeviceHandler.buildProductInfoProperties(999, 999, TIME_ZONE_PROVIDER))
                 .isEmpty();
     }
 
@@ -206,7 +210,7 @@ class ServerSuplaDeviceHandlerTest {
         assertThat(properties.get(SOFTWARE_UPDATE_VERSION_PROPERTY)).isEqualTo("2.0.0");
         assertThat(properties.get(SOFTWARE_UPDATE_URL_PROPERTY)).isEqualTo("https://updates.example/device");
         assertThat(properties.get(SOFTWARE_UPDATE_LAST_CHECK_PROPERTY))
-                .isEqualTo(checkedAt.atZone(ZoneId.systemDefault()).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+                .isEqualTo(checkedAt.atZone(TIME_ZONE).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
     }
 
     @Test
@@ -226,7 +230,7 @@ class ServerSuplaDeviceHandlerTest {
                 .doesNotContainKey(SOFTWARE_UPDATE_VERSION_PROPERTY)
                 .doesNotContainKey(SOFTWARE_UPDATE_URL_PROPERTY);
         assertThat(properties.get(SOFTWARE_UPDATE_LAST_CHECK_PROPERTY))
-                .isEqualTo(checkedAt.atZone(ZoneId.systemDefault()).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+                .isEqualTo(checkedAt.atZone(TIME_ZONE).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
     }
 
     @Test

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/TestServerSuplaDeviceHandler.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/TestServerSuplaDeviceHandler.java
@@ -1,9 +1,11 @@
 package pl.grzeslowski.openhab.supla.internal.server.handler;
 
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.openhab.core.i18n.TimeZoneProvider;
 import org.openhab.core.library.types.HSBType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.OpenClosedType;
@@ -28,11 +30,13 @@ import pl.grzeslowski.openhab.supla.internal.server.traits.DeviceChannelValue;
 import pl.grzeslowski.openhab.supla.internal.server.traits.RegisterDeviceTrait;
 
 final class TestServerSuplaDeviceHandler extends ServerSuplaDeviceHandler {
+    private static final TimeZoneProvider TIME_ZONE_PROVIDER = () -> ZoneId.systemDefault();
+
     private final Map<Integer, ServerDevice.ChannelAndPreviousState> channelNumberToChannelUID =
             Collections.synchronizedMap(new HashMap<>());
 
     TestServerSuplaDeviceHandler(Thing thing) {
-        super(thing, NoopServerDeviceActionServiceRegistry.INSTANCE);
+        super(thing, NoopServerDeviceActionServiceRegistry.INSTANCE, TIME_ZONE_PROVIDER);
     }
 
     @Override

--- a/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/TestServerSuplaDeviceHandler.java
+++ b/src/test/java/pl/grzeslowski/openhab/supla/internal/server/handler/TestServerSuplaDeviceHandler.java
@@ -1,6 +1,5 @@
 package pl.grzeslowski.openhab.supla.internal.server.handler;
 
-import java.time.ZoneId;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -30,13 +29,11 @@ import pl.grzeslowski.openhab.supla.internal.server.traits.DeviceChannelValue;
 import pl.grzeslowski.openhab.supla.internal.server.traits.RegisterDeviceTrait;
 
 final class TestServerSuplaDeviceHandler extends ServerSuplaDeviceHandler {
-    private static final TimeZoneProvider TIME_ZONE_PROVIDER = () -> ZoneId.systemDefault();
-
     private final Map<Integer, ServerDevice.ChannelAndPreviousState> channelNumberToChannelUID =
             Collections.synchronizedMap(new HashMap<>());
 
-    TestServerSuplaDeviceHandler(Thing thing) {
-        super(thing, NoopServerDeviceActionServiceRegistry.INSTANCE, TIME_ZONE_PROVIDER);
+    TestServerSuplaDeviceHandler(Thing thing, TimeZoneProvider timeZoneProvider) {
+        super(thing, NoopServerDeviceActionServiceRegistry.INSTANCE, timeZoneProvider);
     }
 
     @Override


### PR DESCRIPTION
### Motivation
- Ensure timestamps and product release dates are presented in the OpenHAB configured timezone rather than the system default to provide consistent UI and logging times across installations.

### Description
- Introduce a `TimeZoneProvider` reference in `SuplaHandlerFactory` and pass it to `SingleDeviceHandler`, `GatewayDeviceHandler`, and `ServerSuplaDeviceHandler` constructors so device handlers can use the OpenHAB timezone.
- Update `ServerSuplaDeviceHandler` to store the `TimeZoneProvider`, to use it when building product info (`buildProductInfoProperties`) and when formatting software update `checkedAt` timestamps (`updateSoftwareUpdateState`), and to use it for ping/log and local time provisioning (`consumeLocalTimeRequest` / `consumeSuplaPingServer`).
- Add overloads and helper methods (`toOpenHabTimezoneDateTime`) to convert stored ISO datetimes to the OpenHAB timezone and handle parse errors gracefully.
- Adjust constructors and call sites in `GatewayDeviceHandler`, `SingleDeviceHandler`, and test helpers to accept and forward the `TimeZoneProvider`, and update imports and exception handling where needed.

### Testing
- Ran the unit test suite including `ServerSuplaDeviceHandlerTest` and `TestServerSuplaDeviceHandler`; tests were updated to expect timezone-aware ISO datetime formatting and all executed successfully.
- Project compilation and automated tests completed without failures (`mvn test`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c4c215948320bc3a32550ec886e6)