### PR TITLE
Relax OTA integration test timeout

### DIFF
--- a/src/integration-test/java/pl/grzeslowski/openhab/supla/internal/SuplaServerActionsIT.java
+++ b/src/integration-test/java/pl/grzeslowski/openhab/supla/internal/SuplaServerActionsIT.java
@@ -27,6 +27,7 @@ import java.util.function.Supplier;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openhab.core.thing.ThingStatusInfo;
@@ -56,6 +57,7 @@ import pl.grzeslowski.openhab.supla.internal.extension.supla.SuplaExtension;
 import pl.grzeslowski.openhab.supla.internal.server.handler.ServerSuplaDeviceHandler;
 
 @ExtendWith({MockitoExtension.class, RandomExtension.class, RandomBeansExtension.class, SuplaExtension.class})
+@Timeout(value = 60, unit = SECONDS)
 class SuplaServerActionsIT {
     @Test
     @DisplayName("should send check firmware update action to ota-capable device and persist async result")


### PR DESCRIPTION
## Summary
- Add a class-level 60s timeout to SuplaServerActionsIT so OTA socket/action integration tests have CI headroom.
- Keep the global 10s integration-test timeout unchanged for other tests.

## Verification
- mvn -B -ntp spotless:apply
- mvn -B -ntp failsafe:integration-test failsafe:verify
- mvn -B -ntp test
- mvn -B -ntp spotless:check verify