### PR TITLE
[codex] Bump addon for openHAB 5.1

### DIFF
--- a/changelog/4.2.0.md
+++ b/changelog/4.2.0.md
@@ -1,0 +1,7 @@
+## 4.2.0
+
+Released version 4.2.0 - openHAB 5.1 compatibility
+
+### Changed
+- Updated openHAB core dependency target to 5.1.0.
+- Bumped the Supla add-on minor version to 4.2.0.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>pl.grzeslowski.openhab</groupId>
     <artifactId>supla</artifactId>
-    <version>4.1.2-SNAPSHOT</version>
+    <version>4.2.0-SNAPSHOT</version>
 
     <scm>
         <connection>scm:git:${project.scm.url}</connection>
@@ -27,7 +27,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
 
-        <openhab.version>5.0.0</openhab.version>
+        <openhab.version>5.1.0</openhab.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
## Summary
- bump the openHAB core dependency target from 5.0.0 to 5.1.0
- bump the Supla add-on minor version to 4.2.0-SNAPSHOT
- add changelog entry for 4.2.0

## Validation
- `mvn test`
- `mvn spotless:check`